### PR TITLE
[openrewrite] add `NoWhitespaceBefore`

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,59 +5,17 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  issues:
+    types: [opened, assigned]
 
 jobs:
-  check-team-membership:
-    runs-on: ubuntu-latest
-    outputs:
-      is-team-member: ${{ steps.check-membership.outputs.is-member }}
-    steps:
-      - name: Check team membership
-        id: check-membership
-        uses: actions/github-script@v8
-        with:
-          script: |
-            try {
-              // Get username - prioritize sender (the person who triggered the event)
-              const username = github.event?.sender?.login ||
-                              github.event?.comment?.user?.login;
-
-              if (!username) {
-                console.log('Could not determine username from event payload');
-                console.log(`Event type: ${github.event_name}`);
-                console.log(`Event payload keys: ${Object.keys(github.event).join(', ')}`);
-                return false;
-              }
-
-              console.log(`Checking team membership for user: ${username} (triggered by ${github.event_name} event)`);
-
-              const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                org: 'diffplug',
-                team_slug: 'spotless',
-                username: username
-              });
-              console.log(`User ${username} membership status: ${data.state}`);
-              return data.state === 'active';
-            } catch (error) {
-              const username = github.event.sender?.login || github.event.comment?.user?.login || 'unknown user';
-              console.log(`User ${username} is not a member of the Spotless team or error occurred: ${error.message}`);
-              return false;
-            }
-
   claude:
-    needs: check-team-membership
-    if: |
-      needs.check-team-membership.outputs.is-team-member == 'true' &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+    # Only run if @claude is mentioned in the triggering content
+    # For issues (opened/assigned), checks the issue body or title
+    # For comments/reviews, checks the comment/review body
+    if: contains(github.event.comment.body || github.event.review.body || github.event.issue.body || github.event.issue.title || '', '@claude')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,14 +23,44 @@ jobs:
       issues: read
       id-token: write
     steps:
+      - name: Check team membership
+        id: check-membership
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              // Get the user who triggered the event
+              const username = context.payload.sender?.login;
+              
+              if (!username) {
+                core.setFailed('Could not determine username from event');
+                return;
+              }
+              
+              console.log(`Checking if ${username} is a member of diffplug/spotless`);
+              
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'diffplug',
+                team_slug: 'spotless',
+                username: username
+              });
+              
+              if (data.state !== 'active') {
+                core.setFailed(`User ${username} is not an active team member`);
+              } else {
+                console.log(`✓ ${username} is an active team member`);
+              }
+            } catch (error) {
+              // User is not a team member or API error
+              core.setFailed(`Access denied: ${error.message}`);
+            }
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
-        id: claude
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-

--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -1,46 +1,9 @@
 apply plugin: 'org.openrewrite.rewrite'
 
 rewrite {
-	activeRecipe(
-			'org.openrewrite.gradle.GradleBestPractices',
-			'org.openrewrite.java.RemoveUnusedImports',
-			'org.openrewrite.java.format.RemoveTrailingWhitespace',
-			'org.openrewrite.java.migrate.UpgradeToJava17',
-			'org.openrewrite.java.recipes.JavaRecipeBestPractices',
-			'org.openrewrite.java.recipes.RecipeTestingBestPractices',
-			'org.openrewrite.java.security.JavaSecurityBestPractices',
-			'org.openrewrite.staticanalysis.EqualsAvoidsNull',
-			'org.openrewrite.staticanalysis.JavaApiBestPractices',
-			'org.openrewrite.staticanalysis.LowercasePackage',
-			'org.openrewrite.staticanalysis.MissingOverrideAnnotation',
-			'org.openrewrite.staticanalysis.ModifierOrder',
-			'org.openrewrite.staticanalysis.NoFinalizer',
-			'org.openrewrite.staticanalysis.NoToStringOnStringType',
-			'org.openrewrite.staticanalysis.NoValueOfOnStringType',
-			'org.openrewrite.staticanalysis.RemoveUnusedLocalVariables',
-			'org.openrewrite.staticanalysis.RemoveUnusedPrivateFields',
-			'org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods',
-			'org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources',
-			'org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments',
-			'org.openrewrite.staticanalysis.UnnecessaryParentheses',
-			'org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement',
-			'tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.ClassRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.CollectionRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.FileRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.MicrometerRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.PatternRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.PreconditionsRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.PrimitiveRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.StreamRulesRecipes',
-			'tech.picnic.errorprone.refasterrules.TimeRulesRecipes'
-			//'org.openrewrite.staticanalysis.CodeCleanup', bug
-			//'org.openrewrite.staticanalysis.CommonStaticAnalysis', bug
-			//'org.openrewrite.staticanalysis.UnnecessaryThrows', bug
-			)
+	activeRecipe('org.openrewrite.java.format.NoWhitespaceBefore')
 	exclusions.addAll(
+			'**.dirty.java',
 			'**_gradle_node_plugin_example_**',
 			'**gradle/changelog.gradle',
 			'**gradle/java-publish.gradle',
@@ -50,7 +13,10 @@ rewrite {
 			'**lib/build.gradle',
 			'**package-info.java',
 			'**plugin-maven/build.gradle',
-			'**settings.gradle'
+			'**settings.gradle',
+			'**special-tests.gradle',
+			'**FormatterProperties.java',
+			'**testlib/src/main/resources**'
 			)
 	exportDatatables = true
 	failOnDryRunResults = true

--- a/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
+++ b/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
@@ -130,7 +130,7 @@ public class GrEclipseFormatterStepImpl {
 			synchronized (GroovyLogManager.manager) {
 				GroovyLogManager.manager.removeLogger(this);
 			}
-			return 0 != errors.size();
+			return !errors.isEmpty();
 		}
 
 		@Override
@@ -138,7 +138,7 @@ public class GrEclipseFormatterStepImpl {
 			StringBuilder string = new StringBuilder();
 			if (1 < errors.size()) {
 				string.append("Multiple problems detected during step execution:");
-			} else if (0 == errors.size()) {
+			} else if (errors.isEmpty()) {
 				string.append("Step sucesfully executed.");
 			}
 			for (Throwable error : errors) {

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
@@ -164,23 +164,26 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 				return CONSTRUCTORS_INDEX;
 			}
 			int flags = method.getModifiers();
-			if (Modifier.isStatic(flags))
+			if (Modifier.isStatic(flags)) {
 				return STATIC_METHODS_INDEX;
-			else
+			} else {
 				return METHOD_INDEX;
+			}
 		}
 		case ASTNode.FIELD_DECLARATION: {
-			if (JdtFlags.isStatic(bodyDeclaration))
+			if (JdtFlags.isStatic(bodyDeclaration)) {
 				return STATIC_FIELDS_INDEX;
-			else
+			} else {
 				return FIELDS_INDEX;
+			}
 		}
 		case ASTNode.INITIALIZER: {
 			int flags = bodyDeclaration.getModifiers();
-			if (Modifier.isStatic(flags))
+			if (Modifier.isStatic(flags)) {
 				return STATIC_INIT_INDEX;
-			else
+			} else {
 				return INIT_INDEX;
+			}
 		}
 		case ASTNode.TYPE_DECLARATION:
 		case ASTNode.ENUM_DECLARATION:
@@ -280,7 +283,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 			int length2 = parameters2.size();
 
 			int len = Math.min(length1, length2);
-			for (int i = 0; i < len; i++) {
+			for (int i = 0;i < len;i++) {
 				SingleVariableDeclaration param1 = parameters1.get(i);
 				SingleVariableDeclaration param2 = parameters2.get(i);
 				cmp = buildSignature(param1.getType()).compareTo(buildSignature(param2.getType()));

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/JdtFlags.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/JdtFlags.java
@@ -33,17 +33,21 @@ class JdtFlags {
 	static final int VISIBILITY_CODE_INVALID = -1;
 
 	static boolean isStatic(BodyDeclaration bodyDeclaration) {
-		if (isNestedInterfaceOrAnnotation(bodyDeclaration))
+		if (isNestedInterfaceOrAnnotation(bodyDeclaration)) {
 			return true;
+		}
 		int nodeType = bodyDeclaration.getNodeType();
 		if (nodeType != ASTNode.METHOD_DECLARATION
 				&& nodeType != ASTNode.ANNOTATION_TYPE_MEMBER_DECLARATION
-				&& isInterfaceOrAnnotationMember(bodyDeclaration))
+				&& isInterfaceOrAnnotationMember(bodyDeclaration)) {
 			return true;
-		if (bodyDeclaration instanceof EnumConstantDeclaration)
+		}
+		if (bodyDeclaration instanceof EnumConstantDeclaration) {
 			return true;
-		if (bodyDeclaration instanceof EnumDeclaration && bodyDeclaration.getParent() instanceof AbstractTypeDeclaration)
+		}
+		if (bodyDeclaration instanceof EnumDeclaration && bodyDeclaration.getParent() instanceof AbstractTypeDeclaration) {
 			return true;
+		}
 		return Modifier.isStatic(bodyDeclaration.getModifiers());
 	}
 
@@ -60,8 +64,9 @@ class JdtFlags {
 	}
 
 	private static boolean isPublic(BodyDeclaration bodyDeclaration) {
-		if (isInterfaceOrAnnotationMember(bodyDeclaration))
+		if (isInterfaceOrAnnotationMember(bodyDeclaration)) {
 			return true;
+		}
 		return Modifier.isPublic(bodyDeclaration.getModifiers());
 	}
 
@@ -80,14 +85,15 @@ class JdtFlags {
 	}
 
 	static int getVisibilityCode(BodyDeclaration bodyDeclaration) {
-		if (isPublic(bodyDeclaration))
+		if (isPublic(bodyDeclaration)) {
 			return Modifier.PUBLIC;
-		else if (isProtected(bodyDeclaration))
+		} else if (isProtected(bodyDeclaration)) {
 			return Modifier.PROTECTED;
-		else if (isPackageVisible(bodyDeclaration))
+		} else if (isPackageVisible(bodyDeclaration)) {
 			return Modifier.NONE;
-		else if (isPrivate(bodyDeclaration))
+		} else if (isPrivate(bodyDeclaration)) {
 			return Modifier.PRIVATE;
+		}
 		Assert.isTrue(false);
 		return VISIBILITY_CODE_INVALID;
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -78,9 +78,7 @@ public class EclipseBasedStepBuilder {
 
 	/** Returns the FormatterStep (whose state will be calculated lazily). */
 	public FormatterStep build() {
-		var roundtrippableState = new EclipseStep(formatterVersion, formatterStepExt, FileSignature.promise(settingsFiles), JarState.promise(() -> {
-			return JarState.withoutTransitives(dependencies, jarProvisioner);
-		}));
+		var roundtrippableState = new EclipseStep(formatterVersion, formatterStepExt, FileSignature.promise(settingsFiles), JarState.promise(() -> JarState.withoutTransitives(dependencies, jarProvisioner)));
 		return FormatterStep.create(formatterName + formatterStepExt, roundtrippableState,
 				EclipseStep::state, stateToFormatter);
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -61,7 +61,7 @@ public abstract class EquoBasedStepBuilder {
 	private File cacheDirectory;
 
 	/** Initialize valid default configuration, taking latest version */
-	public EquoBasedStepBuilder(
+	protected EquoBasedStepBuilder(
 			String formatterName,
 			Provisioner mavenProvisioner,
 			@Nullable String defaultVersion,

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -177,13 +177,15 @@ public final class GitAttributesLineEndings {
 
 	static class RuntimeInit {
 		/** /etc/gitconfig (system-global), ~/.gitconfig (each might-not exist). */
-		final FileBasedConfig systemConfig, userConfig;
+		final FileBasedConfig systemConfig;
+		final FileBasedConfig userConfig;
 
 		/** Repository specific config, can be $GIT_COMMON_DIR/config, project/.git/config or .git/worktrees/<id>/config.worktree if enabled by extension */
 		final Config repoConfig;
 
 		/** Global .gitattributes file pointed at by systemConfig or userConfig, and the file in the repo. */
-		final @Nullable File globalAttributesFile, repoAttributesFile;
+		final @Nullable File globalAttributesFile;
+		final @Nullable File repoAttributesFile;
 
 		/** git worktree root, might not exist if we're not in a git repo. */
 		final @Nullable File workTree;
@@ -235,7 +237,7 @@ public final class GitAttributesLineEndings {
 	}
 
 	/** https://github.com/git/git/blob/1fe8f2cf461179c41f64efbd1dc0a9fb3b7a0fb1/Documentation/gitattributes.txt */
-	static class Runtime {
+	static final class Runtime {
 		/** .git/info/attributes (and the worktree with that file) */
 		final List<AttributesRule> infoRules;
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -62,7 +62,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 		return isClean(project, treeSha, relativePath);
 	}
 
-	private Map<Repository, DirCache> dirCaches = new HashMap<>();
+	private final Map<Repository, DirCache> dirCaches = new HashMap<>();
 
 	/**
 	 * This is the highest-level method, which all the others serve.  Given the sha

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -38,7 +38,7 @@ public final class EclipseCdtFormatterStep {
 	private EclipseCdtFormatterStep() {}
 
 	private static final String NAME = "eclipse cdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "11.6");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(17, "11.6");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -33,7 +33,7 @@ public final class GrEclipseFormatterStep {
 	private GrEclipseFormatterStep() {}
 
 	private static final String NAME = "eclipse groovy formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "4.26").add(17, "4.35");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(11, "4.26").add(17, "4.35");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();
@@ -66,9 +66,8 @@ public final class GrEclipseFormatterStep {
 						"org.codehaus.groovy.eclipse.core",
 						"org.eclipse.jdt.groovy.core",
 						"org.codehaus.groovy"));
-				model.addFilterAndValidate("no-debug", filter -> {
-					filter.exclude("org.eclipse.jdt.debug");
-				});
+				model.addFilterAndValidate("no-debug", filter ->
+					filter.exclude("org.eclipse.jdt.debug"));
 				// work around https://github.com/groovy/groovy-eclipse/issues/1617
 				model.useMavenCentral = false;
 				return model;

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -112,7 +112,7 @@ public final class DiffMessageFormatter {
 		}
 	}
 
-	public static class Builder {
+	public static final class Builder {
 		private Builder() {}
 
 		private String runToFix;
@@ -161,7 +161,7 @@ public final class DiffMessageFormatter {
 	public static final int MAX_FILES_TO_LIST = 10;
 
 	private final StringBuilder buffer = new StringBuilder(MAX_CHECK_MESSAGE_LINES * 64);
-	private int numLines = 0;
+	private int numLines;
 
 	private final CleanProvider formatter;
 
@@ -203,7 +203,7 @@ public final class DiffMessageFormatter {
 		if (!lines.isEmpty()) {
 			addIntendedLine(NORMAL_INDENT, lines.get(0));
 		}
-		for (int i = 1; i < Math.min(MIN_LINES_PER_FILE, lines.size()); ++i) {
+		for (int i = 1;i < Math.min(MIN_LINES_PER_FILE, lines.size());++i) {
 			addIntendedLine(DIFF_INDENT, lines.get(i));
 		}
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -34,7 +34,7 @@ public final class EclipseJdtFormatterStep {
 	private EclipseJdtFormatterStep() {}
 
 	private static final String NAME = "eclipse jdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "4.26").add(17, "4.35");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(11, "4.26").add(17, "4.35");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -38,7 +38,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatter";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "4.18.0").add(11, "4.21.0");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(8, "4.18.0").add(11, "4.21.0");
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitRachetMergeBaseTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitRachetMergeBaseTest.java
@@ -111,7 +111,7 @@ class GitRachetMergeBaseTest extends ResourceHarness {
 					continue;
 				}
 				boolean expectedClean = !dirtyFiles.contains(file.getName());
-				for (int i = 0; i < shas.length; ++i) {
+				for (int i = 0;i < shas.length;++i) {
 					assertClean(i, file.getName(), expectedClean);
 				}
 			}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
@@ -30,10 +30,9 @@ public class GrEclipseFormatterStepSpecialCaseTest {
 	 */
 	@Test
 	public void issue_1657() {
-		Assertions.assertThrows(RuntimeException.class, () -> {
+		Assertions.assertThrows(RuntimeException.class, () ->
 			StepHarness.forStep(GrEclipseFormatterStep.createBuilder(TestProvisioner.mavenCentral()).build())
-					.testResourceUnaffected("groovy/greclipse/format/SomeClass.test");
-		});
+					.testResourceUnaffected("groovy/greclipse/format/SomeClass.test"));
 	}
 
 	@Test

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -34,10 +34,11 @@ import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.eclipse.EclipseResourceHarness;
 
 public class EclipseWtpFormatterStepTest {
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support("Oldest Version").add(8, "4.8.0");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support("Oldest Version").add(8, "4.8.0");
 
 	private static class NestedTests extends EclipseResourceHarness {
-		private final String unformatted, formatted;
+		private final String unformatted;
+		private final String formatted;
 
 		public NestedTests(String unformatted, String formatted, EclipseWtpFormatterStep kind) {
 			super(kind.createBuilder(TestProvisioner.mavenCentral()));

--- a/lib/src/jackson/java/com/diffplug/spotless/glue/json/AJacksonFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/json/AJacksonFormatterFunc.java
@@ -32,9 +32,9 @@ import com.diffplug.spotless.json.JacksonConfig;
  */
 // https://github.com/FasterXML/jackson-dataformats-text/issues/372
 public abstract class AJacksonFormatterFunc implements FormatterFunc {
-	private JacksonConfig jacksonConfig;
+	private final JacksonConfig jacksonConfig;
 
-	public AJacksonFormatterFunc(JacksonConfig jacksonConfig) {
+	protected AJacksonFormatterFunc(JacksonConfig jacksonConfig) {
 		this.jacksonConfig = jacksonConfig;
 	}
 
@@ -49,9 +49,7 @@ public abstract class AJacksonFormatterFunc implements FormatterFunc {
 		try {
 			// ObjectNode is not compatible with SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS
 			Object objectNode = objectMapper.readValue(input, inferType(input));
-			String output = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
-
-			return output;
+			return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
 		} catch (JsonProcessingException e) {
 			throw new IllegalArgumentException("Unable to format. input='" + input + "'", e);
 		}

--- a/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
@@ -32,7 +32,7 @@ import com.diffplug.spotless.json.JacksonJsonConfig;
  */
 // https://github.com/FasterXML/jackson-dataformats-text/issues/372
 public class JacksonJsonFormatterFunc extends AJacksonFormatterFunc {
-	private JacksonJsonConfig jacksonConfig;
+	private final JacksonJsonConfig jacksonConfig;
 
 	public JacksonJsonFormatterFunc(JacksonJsonConfig jacksonConfig) {
 		super(jacksonConfig);

--- a/lib/src/main/java/com/diffplug/spotless/ConfigurationCacheHackList.java
+++ b/lib/src/main/java/com/diffplug/spotless/ConfigurationCacheHackList.java
@@ -51,7 +51,7 @@ import com.diffplug.spotless.yaml.SerializeToByteArrayHack;
  * It is a horrific hack, but it works, and it's the only way I can figure
  * to make Spotless work with all of Gradle's cache systems at once.
  */
-public class ConfigurationCacheHackList implements java.io.Serializable {
+public final class ConfigurationCacheHackList implements java.io.Serializable {
 	@Serial
 	private static final long serialVersionUID = 6914178791997323870L;
 
@@ -59,7 +59,7 @@ public class ConfigurationCacheHackList implements java.io.Serializable {
 	private ArrayList<Object> backingList = new ArrayList<>();
 
 	private boolean shouldWeSerializeToByteArrayFirst() {
-		return backingList.stream().anyMatch(step -> step instanceof SerializeToByteArrayHack);
+		return backingList.stream().anyMatch(SerializeToByteArrayHack.class::isInstance);
 	}
 
 	private void writeObject(java.io.ObjectOutputStream out) throws IOException {
@@ -83,7 +83,7 @@ public class ConfigurationCacheHackList implements java.io.Serializable {
 		optimizeForEquality = in.readBoolean();
 		backingList = new ArrayList<>();
 		int size = in.readInt();
-		for (int i = 0; i < size; i++) {
+		for (int i = 0;i < size;i++) {
 			if (serializeToByteArrayFirst) {
 				backingList.add(LazyForwardingEquality.fromBytes((byte[]) in.readObject()));
 			} else {
@@ -133,10 +133,12 @@ public class ConfigurationCacheHackList implements java.io.Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
 		ConfigurationCacheHackList stepList = (ConfigurationCacheHackList) o;
 		return optimizeForEquality == stepList.optimizeForEquality &&
 				backingList.equals(stepList.backingList);

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -29,9 +29,9 @@ import java.util.LinkedHashSet;
 
 import javax.annotation.Nullable;
 
-class EncodingErrorMsg {
+final class EncodingErrorMsg {
 	static final char UNREPRESENTABLE = '�';
-	private static int CONTEXT = 3;
+	private static final int CONTEXT = 3;
 
 	static @Nullable String msg(String chars, byte[] bytes, Charset charset) {
 		int unrepresentable = chars.indexOf(UNREPRESENTABLE);
@@ -70,12 +70,12 @@ class EncodingErrorMsg {
 		if (charset.equals(StandardCharsets.UTF_8)) {
 			message.append("Spotless uses UTF-8 by default.");
 		} else {
-			message.append("You configured Spotless to use " + charset.name() + ".");
+			message.append("You configured Spotless to use ").append(charset.name()).append(".");
 		}
 
 		int line = 1;
 		int col = 1;
-		for (int i = 0; i < unrepresentable; ++i) {
+		for (int i = 0;i < unrepresentable;++i) {
 			char c = chars.charAt(i);
 			if (c == '\n') {
 				++line;
@@ -84,7 +84,7 @@ class EncodingErrorMsg {
 				++col;
 			}
 		}
-		message.append("  At line " + line + " col " + col + ":");
+		message.append("  At line ").append(line).append(" col ").append(col).append(":");
 
 		// https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
 		LinkedHashSet<Charset> encodings = new LinkedHashSet<>();

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -76,7 +76,7 @@ public final class FileSignature implements Serializable {
 			StringBuilder builder = new StringBuilder();
 			builder.append("For these files:\n");
 			for (File file : files) {
-				builder.append("  " + file.getAbsolutePath() + "\n");
+				builder.append("  ").append(file.getAbsolutePath()).append("\n");
 			}
 			builder.append("a caching signature is being generated, which will be based only on their\n");
 			builder.append("names, not their full path (foo.txt, not C:\folder\foo.txt). Unexpectedly,\n");
@@ -99,7 +99,7 @@ public final class FileSignature implements Serializable {
 	}
 
 	/** A view of `FileSignature` which can be safely roundtripped. */
-	public static class Promised implements Serializable {
+	public static final class Promised implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 		private final List<File> files;
@@ -146,7 +146,7 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	private static boolean machineIsWin = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+	private static final boolean machineIsWin = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
 
 	/** Returns true if this JVM is running on a windows machine. */
 	public static boolean machineIsWin() {
@@ -186,7 +186,7 @@ public final class FileSignature implements Serializable {
 
 		synchronized Sig sign(File fileInput) throws IOException {
 			String canonicalPath = fileInput.getCanonicalPath();
-			Sig sig = cache.computeIfAbsent(canonicalPath, ThrowingEx.<String, Sig> wrap(p -> {
+			Sig sig = cache.computeIfAbsent(canonicalPath, ThrowingEx.<String, Sig>wrap(p -> {
 				MessageDigest digest = MessageDigest.getInstance("SHA-256");
 				File file = new File(p);
 				// calculate the size and content hash of the file

--- a/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
+++ b/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
@@ -39,7 +39,8 @@ public class ForeignExe implements Serializable {
 	private @Nullable String pathToExe;
 	private String versionFlag = "--version";
 	private Pattern versionRegex = Pattern.compile("version (\\S*)");
-	private @Nullable String fixCantFind, fixWrongVersion;
+	private @Nullable String fixCantFind;
+	private @Nullable String fixWrongVersion;
 
 	// MANDATORY
 	private String name;

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -86,7 +86,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 		return new Formatter.Builder();
 	}
 
-	public static class Builder {
+	public static final class Builder {
 		// required parameters
 		private LineEnding.Policy lineEndingsPolicy;
 		private Charset encoding;
@@ -140,7 +140,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 	}
 
 	static void legacyErrorBehavior(Formatter formatter, File file, ValuePerStep<Throwable> exceptionPerStep) {
-		for (int i = 0; i < formatter.getSteps().size(); ++i) {
+		for (int i = 0;i < formatter.getSteps().size();++i) {
 			Throwable exception = exceptionPerStep.get(i);
 			if (exception != null && exception != LintState.formatStepCausedNoChange()) {
 				logger.error("Step '{}' found problem in '{}':\n{}", formatter.getSteps().get(i).getName(), file.getName(), exception.getMessage(), exception);
@@ -165,7 +165,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 		Objects.requireNonNull(unix, "unix");
 		Objects.requireNonNull(file, "file");
 
-		for (int i = 0; i < steps.size(); ++i) {
+		for (int i = 0;i < steps.size();++i) {
 			FormatterStep step = steps.get(i);
 			Throwable storeForStep;
 			try {
@@ -200,8 +200,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 		int result = 1;
 		result = prime * result + encoding.hashCode();
 		result = prime * result + lineEndingsPolicy.hashCode();
-		result = prime * result + steps.hashCode();
-		return result;
+		return prime * result + steps.hashCode();
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -126,10 +126,12 @@ final class FormatterStepSerializationRoundtrip<RoundtripState extends Serializa
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o)
+			if (this == o) {
 				return true;
-			if (o == null || getClass() != o.getClass())
+			}
+			if (o == null || getClass() != o.getClass()) {
 				return false;
+			}
 			HackClone<?, ?> that = (HackClone<?, ?>) o;
 			return optimizeForEquality == that.optimizeForEquality && rehydrate().equals(that.rehydrate());
 		}

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
@@ -39,7 +39,7 @@ public abstract class GitPrePushHookInstaller {
 
 	private static final Object LOCK = new Object();
 
-	private static volatile boolean installing = false;
+	private static volatile boolean installing;
 
 	/**
 	 * Logger for recording informational and error messages during the installation process.
@@ -57,7 +57,7 @@ public abstract class GitPrePushHookInstaller {
 	 * @param logger The logger for recording messages.
 	 * @param root   The root directory of the Git repository.
 	 */
-	public GitPrePushHookInstaller(GitPreHookLogger logger, File root) {
+	protected GitPrePushHookInstaller(GitPreHookLogger logger, File root) {
 		this.logger = requireNonNull(logger, "logger can not be null");
 		this.root = requireNonNull(root, "root file can not be null");
 	}

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -47,7 +47,7 @@ public final class JarState implements Serializable {
 	private static final Logger logger = LoggerFactory.getLogger(JarState.class);
 
 	// Let the classloader be overridden for tools using different approaches to classloading
-	@Nullable private static ClassLoader forcedClassLoader = null;
+	@Nullable private static ClassLoader forcedClassLoader;
 
 	/** Overrides the classloader used by all JarStates. */
 	public static void setForcedClassLoader(@Nullable ClassLoader forcedClassLoader) {

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -60,7 +60,7 @@ public final class Jvm {
 	 * Utility to map constraints of formatter to this JVM
 	 * @param <V> Version type of formatter
 	 */
-	public static class Support<V> {
+	public static final class Support<V> {
 		static final String LINT_CODE = "jvm-version";
 
 		private final String fmtName;
@@ -268,7 +268,7 @@ public final class Jvm {
 				int numberOfElements = version0Items.length > version1Items.length ? version0Items.length : version1Items.length;
 				version0Items = Arrays.copyOf(version0Items, numberOfElements);
 				version1Items = Arrays.copyOf(version1Items, numberOfElements);
-				for (int i = 0; i < numberOfElements; i++) {
+				for (int i = 0;i < numberOfElements;i++) {
 					if (version0Items[i] > version1Items[i]) {
 						return 1;
 					} else if (version1Items[i] > version0Items[i]) {
@@ -289,7 +289,7 @@ public final class Jvm {
 					throw new IllegalArgumentException("Not a semantic version: %s".formatted(versionObject), e);
 				}
 			}
-		};
+		}
 	}
 
 	/**
@@ -300,6 +300,6 @@ public final class Jvm {
 	 */
 	public static <V> Support<V> support(String formatterName) {
 		Objects.requireNonNull(formatterName);
-		return new Support<V>(formatterName);
+		return new Support<>(formatterName);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/Lint.java
+++ b/lib/src/main/java/com/diffplug/spotless/Lint.java
@@ -45,7 +45,8 @@ public final class Lint implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 
-	private int lineStart, lineEnd; // 1-indexed, inclusive
+	private int lineStart;
+	private int lineEnd; // 1-indexed, inclusive
 	private String shortCode; // e.g. CN_IDIOM https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#cn-class-implements-cloneable-but-does-not-define-or-use-clone-method-cn-idiom
 	private String detail;
 
@@ -128,10 +129,12 @@ public final class Lint implements Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
 		Lint lint = (Lint) o;
 		return lineStart == lint.lineStart && lineEnd == lint.lineEnd && Objects.equals(shortCode, lint.shortCode) && Objects.equals(detail, lint.detail);
 	}
@@ -182,7 +185,7 @@ public final class Lint implements Serializable {
 	}
 
 	private static String msgFrom(String message) {
-		for (int i = 0; i < message.length(); ++i) {
+		for (int i = 0;i < message.length();++i) {
 			if (Character.isLetter(message.charAt(i))) {
 				return message.substring(i);
 			}

--- a/lib/src/main/java/com/diffplug/spotless/LintState.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintState.java
@@ -54,7 +54,7 @@ public class LintState {
 			throw new IllegalStateException("LintState was created with a different formatter!");
 		}
 		LinkedHashMap<String, List<Lint>> result = new LinkedHashMap<>();
-		for (int i = 0; i < lintsPerStep.size(); i++) {
+		for (int i = 0;i < lintsPerStep.size();i++) {
 			List<Lint> lints = lintsPerStep.get(i);
 			if (lints != null) {
 				FormatterStep step = formatter.getSteps().get(i);
@@ -73,7 +73,7 @@ public class LintState {
 		}
 		boolean changed = false;
 		ValuePerStep<List<Lint>> perStepFiltered = new ValuePerStep<>(formatter);
-		for (int i = 0; i < lintsPerStep.size(); i++) {
+		for (int i = 0;i < lintsPerStep.size();i++) {
 			FormatterStep step = formatter.getSteps().get(i);
 			List<Lint> lintsOriginal = lintsPerStep.get(i);
 			if (lintsOriginal != null) {
@@ -114,7 +114,7 @@ public class LintState {
 			return "(none)";
 		} else {
 			StringBuilder result = new StringBuilder();
-			for (int i = 0; i < lintsPerStep.size(); i++) {
+			for (int i = 0;i < lintsPerStep.size();i++) {
 				List<Lint> lints = lintsPerStep.get(i);
 				if (lints != null) {
 					FormatterStep step = formatter.getSteps().get(i);
@@ -143,7 +143,7 @@ public class LintState {
 
 		var lints = new ValuePerStep<List<Lint>>(formatter);
 		// if a step did not throw an exception, then it gets to check for lints if it wants
-		for (int i = 0; i < formatter.getSteps().size(); i++) {
+		for (int i = 0;i < formatter.getSteps().size();i++) {
 			FormatterStep step = formatter.getSteps().get(i);
 			Throwable exception = exceptions.get(i);
 			if (exception == null || exception == formatStepCausedNoChange()) {
@@ -162,7 +162,7 @@ public class LintState {
 		// didn't change the formatted value. so we start at the end, and note when the string
 		// gets changed by a step. if it does, we rerun the steps to get an exception with accurate line numbers.
 		boolean nothingHasChangedSinceLast = true;
-		for (int i = formatter.getSteps().size() - 1; i >= 0; i--) {
+		for (int i = formatter.getSteps().size() - 1;i >= 0;i--) {
 			FormatterStep step = formatter.getSteps().get(i);
 			Throwable exception = exceptions.get(i);
 			if (exception != null && exception != formatStepCausedNoChange()) {

--- a/lib/src/main/java/com/diffplug/spotless/LintSuppression.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintSuppression.java
@@ -77,10 +77,12 @@ public class LintSuppression implements java.io.Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
 		LintSuppression that = (LintSuppression) o;
 		return Objects.equals(path, that.path) && Objects.equals(step, that.step) && Objects.equals(shortCode, that.shortCode);
 	}

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -196,7 +196,8 @@ public class ProcessRunner implements AutoCloseable {
 	public static class Result {
 		private final List<String> args;
 		private final int exitCode;
-		private final byte[] stdOut, stdErr;
+		private final byte[] stdOut;
+		private final byte[] stdErr;
 
 		public Result(@Nonnull List<String> args, int exitCode, @Nonnull byte[] stdOut, @Nullable byte[] stdErr) {
 			this.args = args;
@@ -252,18 +253,18 @@ public class ProcessRunner implements AutoCloseable {
 		@Override
 		public String toString() {
 			StringBuilder builder = new StringBuilder();
-			builder.append("> arguments: " + args + "\n");
-			builder.append("> exit code: " + exitCode + "\n");
+			builder.append("> arguments: ").append(args).append("\n");
+			builder.append("> exit code: ").append(exitCode).append("\n");
 			BiConsumer<String, byte[]> perStream = (name, content) -> {
 				String string = new String(content, Charset.defaultCharset()).trim();
 				if (string.isEmpty()) {
-					builder.append("> " + name + ": (empty)\n");
+					builder.append("> ").append(name).append(": (empty)\n");
 				} else {
 					String[] lines = string.replace("\r", "").split("\n");
 					if (lines.length == 1) {
 						builder.append("> " + name + ": " + lines[0] + "\n");
 					} else {
-						builder.append("> " + name + ": (below)\n");
+						builder.append("> ").append(name).append(": (below)\n");
 						for (String line : lines) {
 							builder.append("> ");
 							builder.append(line);

--- a/lib/src/main/java/com/diffplug/spotless/RingBufferByteArrayOutputStream.java
+++ b/lib/src/main/java/com/diffplug/spotless/RingBufferByteArrayOutputStream.java
@@ -26,9 +26,9 @@ class RingBufferByteArrayOutputStream extends ByteArrayOutputStream {
 
 	private final int limit;
 
-	private int zeroIndexPointer = 0;
+	private int zeroIndexPointer;
 
-	private boolean isOverLimit = false;
+	private boolean isOverLimit;
 
 	public RingBufferByteArrayOutputStream(int limit) {
 		this(limit, 32);

--- a/lib/src/main/java/com/diffplug/spotless/ValuePerStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/ValuePerStep.java
@@ -27,7 +27,7 @@ class ValuePerStep<T> extends AbstractList<T> {
 	private final int size;
 	private @Nullable T value;
 	private int valueIdx;
-	private @Nullable Object[] multipleValues = null;
+	private @Nullable Object[] multipleValues;
 
 	ValuePerStep(Formatter formatter) {
 		this.size = formatter.getSteps().size();
@@ -73,7 +73,7 @@ class ValuePerStep<T> extends AbstractList<T> {
 
 	public int indexOfFirstValue() {
 		if (multipleValues != null) {
-			for (int i = 0; i < multipleValues.length; i++) {
+			for (int i = 0;i < multipleValues.length;i++) {
 				if (multipleValues[i] != null) {
 					return i;
 				}

--- a/lib/src/main/java/com/diffplug/spotless/antlr4/Antlr4Defaults.java
+++ b/lib/src/main/java/com/diffplug/spotless/antlr4/Antlr4Defaults.java
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.antlr4;
 
-public class Antlr4Defaults {
+public final class Antlr4Defaults {
 	private static final String LICENSE_HEADER_DELIMITER = "(grammar|lexer grammar|parser grammar)";
 	private static final String INCLUDES = "src/*/antlr4/**/*.g4";
 

--- a/lib/src/main/java/com/diffplug/spotless/antlr4/Antlr4FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/antlr4/Antlr4FormatterStep.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.ThrowingEx;
 
-public class Antlr4FormatterStep implements Serializable {
+public final class Antlr4FormatterStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "com.khubla.antlr4formatter:antlr4-formatter:";

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
@@ -42,7 +42,7 @@ import com.diffplug.spotless.ProcessRunner;
  * It delegates to the Biome executable. The Biome executable is downloaded from
  * the network when no executable path is provided explicitly.
  */
-public class BiomeStep {
+public final class BiomeStep {
 	private static final Logger logger = LoggerFactory.getLogger(BiomeStep.class);
 
 	/**
@@ -345,7 +345,7 @@ public class BiomeStep {
 	 * caching purposes. Spotless keeps a cache of which files need to be formatted.
 	 * The cache is busted when the serialized form of a state instance changes.
 	 */
-	private static class State implements Serializable {
+	private static final class State implements Serializable {
 		private static final long serialVersionUID = 6846790911054484379L;
 
 		/** Path to the exe file */

--- a/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
@@ -32,7 +32,7 @@ import com.diffplug.spotless.ProcessRunner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class ClangFormatStep {
+public final class ClangFormatStep {
 	public static String name() {
 		return "clang";
 	}

--- a/lib/src/main/java/com/diffplug/spotless/cpp/CppDefaults.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/CppDefaults.java
@@ -19,11 +19,9 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 /** Common utilities for C/C++ */
-public class CppDefaults {
+public final class CppDefaults {
 	//Prevent instantiation
-	private CppDefaults() {};
-
-	/**
+	private CppDefaults() {}/**
 	 * Default delimiter expression shall cover most valid and common starts of C/C++ declarations and definitions.
 	 * Furthermore it shall not conflict with terms commonly used within license headers.
 	 * Note that the longest match is selected. Hence "using namespace foo" is preferred over "namespace foo".
@@ -37,8 +35,6 @@ public class CppDefaults {
 			"int8_t", "int16_t", "int32_t", "int64_t",
 			"__int8_t", "__int16_t", "__int32_t", "__int64_t",
 			"uint8_t", "uint16_t", "uint32_t", "uint64_t")
-			.stream().map(s -> {
-				return "(?<![0-9a-zA-Z]+)" + s.replaceAll("#", "\\\\#").replaceAll(" ", "[\\\\n\\\\s]+") + "[\\*\\s\\n]+";
-			}).collect(Collectors.joining("|"));
+			.stream().map(s -> "(?<![0-9a-zA-Z]+)" + s.replaceAll("#", "\\\\#").replaceAll(" ", "[\\\\n\\\\s]+") + "[\\*\\s\\n]+").collect(Collectors.joining("|"));
 
 }

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -31,7 +31,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.Lint;
 
-public class FenceStep {
+public final class FenceStep {
 	/** Declares the name of the step. */
 	public static FenceStep named(String name) {
 		return new FenceStep(name);
@@ -100,7 +100,7 @@ public class FenceStep {
 		APPLY, PRESERVE
 	}
 
-	private static class RoundtripAndEqualityState implements Serializable {
+	private static final class RoundtripAndEqualityState implements Serializable {
 		private static final long serialVersionUID = 272603249547598947L;
 		final String regexPattern;
 		final int regexFlags;

--- a/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
@@ -133,7 +133,7 @@ public final class IdeaStep {
 		}
 	}
 
-	private static class State implements Serializable {
+	private static final class State implements Serializable {
 
 		private static final long serialVersionUID = -1426311255869303398L;
 
@@ -232,9 +232,8 @@ public final class IdeaStep {
 
 		private Map<String, String> createEnv() {
 			File ideaProps = createIdeaPropertiesFile();
-			Map<String, String> env = Map.ofEntries(
+			return Map.ofEntries(
 					Map.entry("IDEA_PROPERTIES", ThrowingEx.get(ideaProps::getCanonicalPath)));
-			return env;
 		}
 
 		private File createIdeaPropertiesFile() {
@@ -269,7 +268,7 @@ public final class IdeaStep {
 
 		private List<String> getParams(File file) {
 			/* https://www.jetbrains.com/help/idea/command-line-formatter.html */
-			var builder = Stream.<String> builder();
+			var builder = Stream.<String>builder();
 			builder.add(binaryPath);
 			builder.add("format");
 			if (withDefaults) {

--- a/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
@@ -104,12 +104,12 @@ public final class IndentStep implements Serializable {
 				if (numSpaces > 0) {
 					switch (state.type) {
 					case SPACE:
-						for (int i = 0; i < numSpaces; ++i) {
+						for (int i = 0;i < numSpaces;++i) {
 							builder.append(' ');
 						}
 						break;
 					case TAB:
-						for (int i = 0; i < numSpaces / state.numSpacesPerTab; ++i) {
+						for (int i = 0;i < numSpaces / state.numSpacesPerTab;++i) {
 							builder.append('\t');
 						}
 						if (mightBeMultiLineComment && (numSpaces % state.numSpacesPerTab == 1)) {

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -206,11 +206,11 @@ public final class LicenseHeaderStep {
 
 	public static final String spotlessSetLicenseHeaderYearsFromGitHistory = "spotlessSetLicenseHeaderYearsFromGitHistory";
 
-	public static final String FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY() {
+	public static String FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY() {
 		return spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
-	private static class Runtime implements Serializable {
+	private static final class Runtime implements Serializable {
 		private static final long serialVersionUID = 1475199492829130965L;
 
 		private final Pattern delimiterPattern;
@@ -305,8 +305,7 @@ public final class LicenseHeaderStep {
 
 		private String addOrUpdateLicenseHeader(String raw, File file) {
 			raw = replaceYear(raw);
-			raw = replaceFileName(raw, file);
-			return raw;
+			return replaceFileName(raw, file);
 		}
 
 		private String replaceYear(String raw) {

--- a/lib/src/main/java/com/diffplug/spotless/generic/NativeCmdStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/NativeCmdStep.java
@@ -28,7 +28,7 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ProcessRunner;
 
-public class NativeCmdStep {
+public final class NativeCmdStep {
 	// prevent direct instantiation
 	private NativeCmdStep() {}
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/TestEnvVars.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/TestEnvVars.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-class TestEnvVars {
+final class TestEnvVars {
 
 	private final Map<String, String> envVars;
 

--- a/lib/src/main/java/com/diffplug/spotless/gherkin/GherkinUtilsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/gherkin/GherkinUtilsStep.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
-public class GherkinUtilsStep implements Serializable {
+public final class GherkinUtilsStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "io.cucumber:gherkin-utils:";

--- a/lib/src/main/java/com/diffplug/spotless/go/GofmtFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/go/GofmtFormatStep.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Note: gofmt doesn't have a version flag, because it's part of standard Go distribution.
  * So `go` executable can be used to determine base path and version, and path to gofmt can be built from it.
  */
-public class GofmtFormatStep {
+public final class GofmtFormatStep {
 	public static String name() {
 		return "gofmt";
 	}

--- a/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
@@ -45,7 +45,7 @@ public final class CleanthatJavaStep implements Serializable {
 	/**
 	 * CleanThat changelog is available at <a href="https://github.com/solven-eu/cleanthat/blob/master/CHANGES.MD">here</a>.
 	 */
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "2.23");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(11, "2.23");
 
 	private final JarState.Promised jarState;
 	private final String version;
@@ -174,7 +174,7 @@ public final class CleanthatJavaStep implements Serializable {
 			this.includeDraft = includeDraft;
 		}
 
-		private static class JvmSupportFormatterFunc implements FormatterFunc {
+		private static final class JvmSupportFormatterFunc implements FormatterFunc {
 
 			final Object formatter;
 			final Method formatterMethod;

--- a/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
@@ -469,7 +469,7 @@ public final class FormatAnnotationsStep implements Serializable {
 		String fixupTypeAnnotations(String unixStr) {
 			// Each element of `lines` ends with a newline.
 			String[] lines = unixStr.split("((?<=\n))");
-			for (int i = 0; i < lines.length - 1; i++) {
+			for (int i = 0;i < lines.length - 1;i++) {
 				String line = lines[i];
 				if (endsWithTypeAnnotation(line)) {
 					String nextLine = lines[i + 1];

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -27,7 +27,7 @@ import com.diffplug.spotless.Jvm;
 import com.diffplug.spotless.Provisioner;
 
 /** Wraps up <a href="https://github.com/google/google-java-format">google-java-format</a> as a FormatterStep. */
-public class GoogleJavaFormatStep implements Serializable {
+public final class GoogleJavaFormatStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_STYLE = "GOOGLE";
@@ -119,7 +119,7 @@ public class GoogleJavaFormatStep implements Serializable {
 		}
 	}
 
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME)
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME)
 			.addMin(11, "1.8") // we only support google-java-format >= 1.8 due to api changes
 			.addMin(16, "1.10.0") // java 16 requires at least 1.10.0 due to jdk api changes in JavaTokenizer
 			.addMin(21, "1.17.0") // java 21 requires at least 1.17.0 due to https://github.com/google/google-java-format/issues/898

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -112,7 +112,7 @@ final class ImportSorterImpl {
 		}
 
 		int indexOfFirstStatic = 0;
-		for (int i = 0; i < importsGroups.size(); i++) {
+		for (int i = 0;i < importsGroups.size();i++) {
 			boolean subgroupMatch = importsGroups.get(i).getSubGroups().stream().anyMatch(subgroup -> subgroup.startsWith(STATIC_KEYWORD));
 			if (subgroupMatch) {
 				indexOfFirstStatic = i;
@@ -230,7 +230,7 @@ final class ImportSorterImpl {
 		if (order1.equals(order2)) {
 			throw new IllegalArgumentException("orders are same");
 		}
-		for (int i = 0; i < anImport.length() - 1; i++) {
+		for (int i = 0;i < anImport.length() - 1;i++) {
 			if (order1.length() - 1 == i && order2.length() - 1 != i) {
 				return order2;
 			}
@@ -267,7 +267,7 @@ final class ImportSorterImpl {
 		return string1IsWildcard == wildcardsLast ? 1 : -1;
 	}
 
-	private static class LexicographicalOrderingComparator implements Comparator<String>, Serializable {
+	private static final class LexicographicalOrderingComparator implements Comparator<String>, Serializable {
 		private static final long serialVersionUID = 1;
 
 		private final boolean wildcardsLast;
@@ -282,7 +282,7 @@ final class ImportSorterImpl {
 		}
 	}
 
-	private static class SemanticOrderingComparator implements Comparator<String>, Serializable {
+	private static final class SemanticOrderingComparator implements Comparator<String>, Serializable {
 		private static final long serialVersionUID = 1;
 
 		private final boolean wildcardsLast;
@@ -322,8 +322,9 @@ final class ImportSorterImpl {
 				String member2 = split[1];
 
 				int result = compareFullyQualifiedClassName(fqcn1, fqcn2);
-				if (result != 0)
+				if (result != 0) {
 					return result;
+				}
 
 				return compareWithWildcare(member1, member2, wildcardsLast);
 			} else {
@@ -345,8 +346,9 @@ final class ImportSorterImpl {
 			String c2 = split[1];
 
 			int result = p1.compareTo(p2);
-			if (result != 0)
+			if (result != 0) {
 				return result;
+			}
 
 			return compareWithWildcare(c1, c2, wildcardsLast);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
@@ -52,7 +52,7 @@ final class ModuleHelper {
 		REQUIRED_PACKAGES_TO_TEST_CLASSES.putIfAbsent("com.sun.tools.javac.api", "DiagnosticFormatter$PositionKind");
 	}
 
-	private static boolean checkDone = false;
+	private static boolean checkDone;
 
 	public static synchronized void doOpenInternalPackagesIfRequired() {
 		if (Jvm.version() < 16 || checkDone) {

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -28,14 +28,14 @@ import com.diffplug.spotless.Provisioner;
 
 /** Wraps up <a href="https://github.com/palantir/palantir-java-format">palantir-java-format</a> fork of
  * <a href="https://github.com/google/google-java-format">google-java-format</a> as a FormatterStep. */
-public class PalantirJavaFormatStep implements Serializable {
+public final class PalantirJavaFormatStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final boolean DEFAULT_FORMAT_JAVADOC = false;
 	private static final String DEFAULT_STYLE = "PALANTIR";
 	private static final String NAME = "palantir-java-format";
 	public static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.71.0");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String>support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.71.0");
 
 	/** The jar that contains the formatter. */
 	private final JarState.Promised jarState;

--- a/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedImportsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedImportsStep.java
@@ -24,7 +24,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.Provisioner;
 
 /** Uses google-java-format or cleanthat.UnnecessaryImport, but only to remove unused imports. */
-public class RemoveUnusedImportsStep implements Serializable {
+public final class RemoveUnusedImportsStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	static final String NAME = "removeUnusedImports";

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
@@ -31,7 +31,7 @@ public class JacksonJsonConfig extends JacksonConfig {
 
 	// https://github.com/revelc/formatter-maven-plugin/pull/280
 	// By default, Jackson adds a ' ' before separator, which is not standard with most IDE/JSON libraries
-	protected boolean spaceBeforeSeparator = false;
+	protected boolean spaceBeforeSeparator;
 
 	public Map<String, Boolean> getJsonFeatureToToggle() {
 		return Collections.unmodifiableMap(jsonFeatureToToggle);

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonStep.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.Provisioner;
  * Simple YAML formatter which reformats the file according to Jackson YAMLFactory.
  */
 // https://stackoverflow.com/questions/14515994/convert-json-string-to-pretty-print-json-output-using-jackson
-public class JacksonJsonStep implements Serializable {
+public final class JacksonJsonStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "com.fasterxml.jackson.core:jackson-databind:";

--- a/lib/src/main/java/com/diffplug/spotless/json/JsonPatchStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JsonPatchStep.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
-public class JsonPatchStep implements Serializable {
+public final class JsonPatchStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "com.flipkart.zjsonpatch:zjsonpatch";

--- a/lib/src/main/java/com/diffplug/spotless/json/gson/GsonStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/gson/GsonStep.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
-public class GsonStep implements Serializable {
+public final class GsonStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATES = "com.google.code.gson:gson";

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
 /** Wraps up <a href="https://github.com/cqfn/diKTat">diktat</a> as a FormatterStep. */
-public class DiktatStep implements Serializable {
+public final class DiktatStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private final JarState.Promised jarState;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -35,7 +35,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
 /** Wraps up <a href="https://github.com/pinterest/ktlint">ktlint</a> as a FormatterStep. */
-public class KtLintStep implements Serializable {
+public final class KtLintStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_VERSION = "1.7.1";

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -39,7 +39,7 @@ import com.diffplug.spotless.ThrowingEx;
 /**
  * Wraps up <a href="https://github.com/facebook/ktfmt">ktfmt</a> as a FormatterStep.
  */
-public class KtfmtStep implements Serializable {
+public final class KtfmtStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_VERSION = "0.58";
@@ -147,13 +147,13 @@ public class KtfmtStep implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 
-		@Nullable private Integer maxWidth = null;
+		@Nullable private Integer maxWidth;
 
-		@Nullable private Integer blockIndent = null;
+		@Nullable private Integer blockIndent;
 
-		@Nullable private Integer continuationIndent = null;
+		@Nullable private Integer continuationIndent;
 
-		@Nullable private Boolean removeUnusedImports = null;
+		@Nullable private Boolean removeUnusedImports;
 
 		@Nullable private TrailingCommaManagementStrategy trailingCommaManagementStrategy;
 

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
 /** A step for <a href="https://github.com/vsch/flexmark-java">flexmark-java</a>. */
-public class FlexmarkStep implements Serializable {
+public final class FlexmarkStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_VERSION = "0.64.8";

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
@@ -38,7 +38,7 @@ import com.diffplug.spotless.Jvm;
 import com.diffplug.spotless.Provisioner;
 
 /** A step for <a href="https://github.com/diffplug/freshmark">FreshMark</a>. */
-public class FreshMarkStep implements Serializable {
+public final class FreshMarkStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
@@ -37,7 +37,7 @@ interface ExclusiveFolderAccess {
 
 	void runExclusively(ThrowingEx.Runnable runnable);
 
-	class ExclusiveFolderAccessSharedMutex implements ExclusiveFolderAccess {
+	final class ExclusiveFolderAccessSharedMutex implements ExclusiveFolderAccess {
 
 		private static final ConcurrentHashMap<String, Lock> mutexes = new ConcurrentHashMap<>();
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/FileFinder.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/FileFinder.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-class FileFinder {
+final class FileFinder {
 
 	private final List<Supplier<Optional<File>>> fileCandidateFinders;
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/JsonEscaper.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/JsonEscaper.java
@@ -76,7 +76,7 @@ final class JsonEscaper {
 		escaped.append('"');
 		char b;
 		char c = 0;
-		for (int i = 0; i < unescaped.length(); i++) {
+		for (int i = 0;i < unescaped.length();i++) {
 			b = c;
 			c = unescaped.charAt(i);
 			switch (c) {

--- a/lib/src/main/java/com/diffplug/spotless/npm/JsonRawValue.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/JsonRawValue.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Wrapper class to signal the contained string must not be escaped when printing to json.
  */
-class JsonRawValue {
+final class JsonRawValue {
 	private final String rawJson;
 
 	private JsonRawValue(String rawJson) {

--- a/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
-class ListableAdapter<T> implements Iterable<T> {
+final class ListableAdapter<T> implements Iterable<T> {
 
 	private final List<T> delegate;
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
@@ -18,7 +18,7 @@ package com.diffplug.spotless.npm;
 import java.io.File;
 import java.util.Optional;
 
-class NodeExecutableResolver {
+final class NodeExecutableResolver {
 
 	private NodeExecutableResolver() {
 		// no instance

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import com.diffplug.spotless.ProcessRunner.Result;
 
-public class NodeModulesCachingNpmProcessFactory implements NpmProcessFactory {
+public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFactory {
 
 	private static final Logger logger = LoggerFactory.getLogger(NodeModulesCachingNpmProcessFactory.class);
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/PlatformInfo.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PlatformInfo.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Locale;
 
-class PlatformInfo {
+final class PlatformInfo {
 	private PlatformInfo() {
 		// no instance
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -43,11 +43,11 @@ public class PrettierFormatterStep {
 
 	public static final String DEFAULT_VERSION = "2.8.8";
 
-	public static final Map<String, String> defaultDevDependencies() {
+	public static Map<String, String> defaultDevDependencies() {
 		return defaultDevDependenciesWithPrettier(DEFAULT_VERSION);
 	}
 
-	public static final Map<String, String> defaultDevDependenciesWithPrettier(String version) {
+	public static Map<String, String> defaultDevDependenciesWithPrettier(String version) {
 		return Collections.singletonMap("prettier", version);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
@@ -113,7 +113,7 @@ class PrettierMissingParserException extends RuntimeException implements Lint.Ha
 		return EXTENSIONS_TO_PLUGINS.entrySet().stream()
 				.filter(entry -> file.getName().endsWith(entry.getKey()))
 				.findFirst()
-				.map(entry -> entry.getValue())
+				.map(Map.Entry::getValue)
 				.orElse("prettier-plugin-" + extension(file));
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-class SimpleRestClient {
+final class SimpleRestClient {
 	private final String baseUrl;
 
 	private SimpleRestClient(String baseUrl) {
@@ -72,8 +72,7 @@ class SimpleRestClient {
 				throw new SimpleRestResponseException(status, readError(con), "Unexpected response status code at " + endpoint);
 			}
 
-			String response = readResponse(con);
-			return response;
+			return readResponse(con);
 		} catch (IOException e) {
 			throw new SimpleRestIOException(e);
 		}
@@ -96,9 +95,9 @@ class SimpleRestClient {
 	abstract static class SimpleRestException extends RuntimeException {
 		private static final long serialVersionUID = -8260821395756603787L;
 
-		public SimpleRestException() {}
+		protected SimpleRestException() {}
 
-		public SimpleRestException(Throwable cause) {
+		protected SimpleRestException(Throwable cause) {
 			super(cause);
 		}
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutionException;
 
 import com.diffplug.spotless.ProcessRunner;
 
-public class StandardNpmProcessFactory implements NpmProcessFactory {
+public final class StandardNpmProcessFactory implements NpmProcessFactory {
 
 	public static final StandardNpmProcessFactory INSTANCE = new StandardNpmProcessFactory();
 
@@ -48,7 +48,7 @@ public class StandardNpmProcessFactory implements NpmProcessFactory {
 		protected final File workingDir;
 		protected final NpmFormatterStepLocations formatterStepLocations;
 
-		public AbstractStandardNpmProcess(File workingDir, NpmFormatterStepLocations formatterStepLocations) {
+		protected AbstractStandardNpmProcess(File workingDir, NpmFormatterStepLocations formatterStepLocations) {
 			this.formatterStepLocations = formatterStepLocations;
 			this.workingDir = workingDir;
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/TimedLogger.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TimedLogger.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.ThrowingEx;
 /**
  * A logger that logs the time it took to execute a block of code.
  */
-class TimedLogger {
+final class TimedLogger {
 
 	public static final String MESSAGE_PREFIX_BEGIN = "[BEGIN] ";
 
@@ -158,7 +158,7 @@ class TimedLogger {
 	}
 
 	static class TestTicker implements Ticker {
-		private long time = 0;
+		private long time;
 
 		@Override
 		public long read() {

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
@@ -31,7 +31,7 @@ public class SortPomCfg implements Serializable {
 
 	public boolean expandEmptyElements;
 
-	public boolean spaceBeforeCloseEmptyElement = false;
+	public boolean spaceBeforeCloseEmptyElement;
 
 	public boolean keepBlankLines = true;
 
@@ -39,29 +39,29 @@ public class SortPomCfg implements Serializable {
 
 	public int nrOfIndentSpace = 2;
 
-	public boolean indentBlankLines = false;
+	public boolean indentBlankLines;
 
-	public boolean indentSchemaLocation = false;
+	public boolean indentSchemaLocation;
 
-	public String indentAttribute = null;
+	public String indentAttribute;
 
 	public String predefinedSortOrder = "recommended_2008_06";
 
-	public boolean quiet = false;
+	public boolean quiet;
 
-	public String sortOrderFile = null;
+	public String sortOrderFile;
 
-	public String sortDependencies = null;
+	public String sortDependencies;
 
-	public String sortDependencyManagement = null;
+	public String sortDependencyManagement;
 
-	public String sortDependencyExclusions = null;
+	public String sortDependencyExclusions;
 
-	public String sortPlugins = null;
+	public String sortPlugins;
 
-	public boolean sortProperties = false;
+	public boolean sortProperties;
 
-	public boolean sortModules = false;
+	public boolean sortModules;
 
-	public boolean sortExecutions = false;
+	public boolean sortExecutions;
 }

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomStep.java
@@ -25,7 +25,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
-public class SortPomStep implements Serializable {
+public final class SortPomStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "com.github.ekryd.sortpom:sortpom-sorter:";

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -32,7 +32,7 @@ import com.diffplug.spotless.ProcessRunner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class BufStep {
+public final class BufStep {
 	public static String name() {
 		return "buf";
 	}

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.ProcessRunner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class BlackStep {
+public final class BlackStep {
 	public static String name() {
 		return "black";
 	}

--- a/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterConfig.java
@@ -92,10 +92,12 @@ public class RdfFormatterConfig implements Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (!(o instanceof RdfFormatterConfig))
+		}
+		if (!(o instanceof RdfFormatterConfig)) {
 			return false;
+		}
 		RdfFormatterConfig that = (RdfFormatterConfig) o;
 		return isFailOnWarning() == that.isFailOnWarning()
 				&& Objects.equals(turtleFormatterVersion, that.turtleFormatterVersion);

--- a/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterFunc.java
@@ -153,9 +153,9 @@ public class RdfFormatterFunc implements FormatterFunc {
 				})
 				.collect(Collectors.toList());
 		if (!(onlyInBeforeContent.isEmpty() && onlyInAfterContent.isEmpty())) {
-			diffResult = onlyInBeforeContent.stream().map(s -> "< %s".formatted(s))
+			diffResult = onlyInBeforeContent.stream().map("< %s"::formatted)
 					.collect(Collectors.joining("\n"));
-			diffResult += "\n" + onlyInAfterContent.stream().map(s -> "> %s".formatted(s)).collect(Collectors.joining("\n"));
+			diffResult += "\n" + onlyInAfterContent.stream().map("> %s"::formatted).collect(Collectors.joining("\n"));
 		} else {
 			diffResult = "'before' and 'after' content differs, but we don't know why. This is probably a bug.";
 		}

--- a/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterStep.java
@@ -92,10 +92,12 @@ public class RdfFormatterStep implements Serializable {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o)
+			if (this == o) {
 				return true;
-			if (!(o instanceof State))
+			}
+			if (!(o instanceof State)) {
 				return false;
+			}
 			State state = (State) o;
 			return Objects.equals(getConfig(), state.getConfig()) && Objects.equals(
 					getTurtleFormatterStyle(), state.getTurtleFormatterStyle())

--- a/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
@@ -76,8 +76,8 @@ class ReflectionHelper {
 	private final Method getGraph;
 	private final Method tripleGetObject;
 
-	private Object turtleFormatter = null;
-	private Object jenaModelInstance = null;
+	private Object turtleFormatter;
+	private final Object jenaModelInstance;
 
 	public ReflectionHelper(RdfFormatterStep.State state)
 			throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
@@ -271,8 +271,7 @@ class ReflectionHelper {
 			Method method = getBuilderMethod(optionName);
 			callBuilderMethod(builder, method, state.getTurtleFormatterStyle().get(optionName));
 		}
-		Object style = TurtleFormatFormattingStyleBuilderClass.getMethod("build").invoke(builder);
-		return style;
+		return TurtleFormatFormattingStyleBuilderClass.getMethod("build").invoke(builder);
 	}
 
 	public String formatWithTurtleFormatter(String ttlContent)
@@ -284,9 +283,8 @@ class ReflectionHelper {
 
 	private Object newTurtleFormatter(Object style)
 			throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-		Object formatter = TurtleFormatFormatterClass.getConstructor(TurtleFormatFormattingStyleClass)
+		return TurtleFormatFormatterClass.getConstructor(TurtleFormatFormattingStyleClass)
 				.newInstance(style);
-		return formatter;
 	}
 
 	private void callBuilderMethod(Object builder, Method method, String parameterValueAsString)
@@ -346,14 +344,13 @@ class ReflectionHelper {
 
 	private Object makeListOf(Type type, String parameterValueAsString) {
 		String[] entries = split(parameterValueAsString);
-		List<Object> ret = Arrays.stream(entries).map(e -> {
+		return Arrays.stream(entries).map(e -> {
 			try {
 				return instantiate(type, e);
 			} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException ex) {
 				throw new RuntimeException(ex);
 			}
 		}).collect(Collectors.toList());
-		return ret;
 	}
 
 	private Object makeSetOf(Type type, String parameterValueAsString) {

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -31,7 +31,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
 /** Wraps up <a href="https://github.com/scalameta/scalafmt">scalafmt</a> as a FormatterStep. */
-public class ScalaFmtStep implements Serializable {
+public final class ScalaFmtStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 

--- a/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
@@ -34,7 +34,7 @@ import com.diffplug.spotless.ProcessRunner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class ShfmtStep {
+public final class ShfmtStep {
 	public static String name() {
 		return "shfmt";
 	}

--- a/lib/src/main/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStep.java
@@ -23,7 +23,7 @@ import com.diffplug.spotless.FormatterProperties;
 import com.diffplug.spotless.FormatterStep;
 
 /** SQL formatter step which wraps up DBeaver's SqlTokenizedFormatter implementation. */
-public class DBeaverSQLFormatterStep {
+public final class DBeaverSQLFormatterStep {
 
 	private static final String NAME = "dbeaverSql";
 

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
@@ -67,7 +67,7 @@ public class DBeaverSQLFormatterConfiguration {
 	private String getIndentString(String indentType, int indentSize) {
 		char indentChar = "space".equals(indentType) ? ' ' : '\t';
 		StringBuilder stringBuilder = new StringBuilder();
-		for (int i = 0; i < indentSize; i++) {
+		for (int i = 0;i < indentSize;i++) {
 			stringBuilder.append(indentChar);
 		}
 		return stringBuilder.toString();

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLDialect.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLDialect.java
@@ -31,7 +31,7 @@ import java.util.TreeSet;
  * Based on SQLDialect from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */
-class SQLDialect {
+final class SQLDialect {
 
 	private static final String[] DEFAULT_LINE_COMMENTS = {SQLConstants.SL_COMMENT};
 	private static final String[] EXEC_KEYWORDS = new String[0];
@@ -39,12 +39,12 @@ class SQLDialect {
 	private static final String[][] DEFAULT_QUOTE_STRINGS = {{"\"", "\""}};
 
 	// Keywords
-	private TreeMap<String, DBPKeywordType> allKeywords = new TreeMap<>();
+	private final TreeMap<String, DBPKeywordType> allKeywords = new TreeMap<>();
 
 	private final TreeSet<String> functions = new TreeSet<>();
 	private final TreeSet<String> types = new TreeSet<>();
 	// Comments
-	private Pair<String, String> multiLineComments = new Pair<>(SQLConstants.ML_COMMENT_START, SQLConstants.ML_COMMENT_END);
+	private final Pair<String, String> multiLineComments = new Pair<>(SQLConstants.ML_COMMENT_START, SQLConstants.ML_COMMENT_END);
 
 	static final SQLDialect INSTANCE = new SQLDialect();
 

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -103,7 +103,7 @@ public class SQLTokenizedFormatter {
 		}
 
 		// Remove extra tokens (spaces, etc)
-		for (int index = argList.size() - 1; index >= 1; index--) {
+		for (int index = argList.size() - 1;index >= 1;index--) {
 			token = argList.get(index);
 			FormatterToken prevToken = argList.get(index - 1);
 			if (token.getType() == TokenType.SPACE && (prevToken.getType() == TokenType.SYMBOL || prevToken.getType() == TokenType.COMMENT)) {
@@ -115,7 +115,7 @@ public class SQLTokenizedFormatter {
 			}
 		}
 
-		for (int index = 0; index < argList.size() - 2; index++) {
+		for (int index = 0;index < argList.size() - 2;index++) {
 			FormatterToken t0 = argList.get(index);
 			FormatterToken t1 = argList.get(index + 1);
 			FormatterToken t2 = argList.get(index + 2);
@@ -151,7 +151,7 @@ public class SQLTokenizedFormatter {
 		final List<Integer> bracketIndent = new ArrayList<>();
 		FormatterToken prev = new FormatterToken(TokenType.SPACE, " ");
 		boolean encounterBetween = false;
-		for (int index = 0; index < argList.size(); index++) {
+		for (int index = 0;index < argList.size();index++) {
 			token = argList.get(index);
 			String tokenString = token.getString().toUpperCase(Locale.ENGLISH);
 			if (token.getType() == TokenType.SYMBOL) {
@@ -281,7 +281,7 @@ public class SQLTokenizedFormatter {
 			prev = token;
 		}
 
-		for (int index = argList.size() - 1; index >= 4; index--) {
+		for (int index = argList.size() - 1;index >= 4;index--) {
 			if (index >= argList.size()) {
 				continue;
 			}
@@ -304,7 +304,7 @@ public class SQLTokenizedFormatter {
 			}
 		}
 
-		for (int index = 1; index < argList.size(); index++) {
+		for (int index = 1;index < argList.size();index++) {
 			prev = argList.get(index - 1);
 			token = argList.get(index);
 
@@ -355,7 +355,7 @@ public class SQLTokenizedFormatter {
 			return false;
 		}
 		// check previous token
-		for (int i = index - 1; i >= 0; i--) {
+		for (int i = index - 1;i >= 0;i--) {
 			FormatterToken token = argList.get(i);
 			if (token.getType() == TokenType.SPACE) {
 				continue;
@@ -368,7 +368,7 @@ public class SQLTokenizedFormatter {
 			}
 		}
 		// check last token
-		for (int i = index; i < argList.size(); i++) {
+		for (int i = index;i < argList.size();i++) {
 			FormatterToken token = argList.get(i);
 			if (token.getType() == TokenType.SPACE) {
 				continue;
@@ -393,12 +393,13 @@ public class SQLTokenizedFormatter {
 	}
 
 	private int insertReturnAndIndent(final List<FormatterToken> argList, final int argIndex, final int argIndent) {
-		if (functionBracket.contains(Boolean.TRUE))
+		if (functionBracket.contains(Boolean.TRUE)) {
 			return 0;
+		}
 		try {
 			final String defaultLineSeparator = getDefaultLineSeparator();
 			StringBuilder s = new StringBuilder(defaultLineSeparator);
-			for (int index = 0; index < argIndent; index++) {
+			for (int index = 0;index < argIndent;index++) {
 				s.append(formatterCfg.getIndentString());
 			}
 			if (argIndex > 0) {
@@ -456,11 +457,13 @@ public class SQLTokenizedFormatter {
 	}
 
 	private static <OBJECT_TYPE> boolean contains(OBJECT_TYPE[] array, OBJECT_TYPE value) {
-		if (array == null || array.length == 0)
+		if (array == null || array.length == 0) {
 			return false;
+		}
 		for (OBJECT_TYPE anArray : array) {
-			if (Objects.equals(value, anArray))
+			if (Objects.equals(value, anArray)) {
 				return true;
+			}
 		}
 		return false;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
@@ -35,13 +35,13 @@ class SQLTokensParser {
 	private static final SQLDialect sqlDialect = SQLDialect.INSTANCE;
 
 	private final String[][] quoteStrings;
-	private String fBefore = null;
+	private String fBefore;
 	private int fPos;
-	private char structSeparator;
-	private String catalogSeparator;
-	private Set<String> commands = new HashSet<>();
-	private String[] singleLineComments;
-	private char[] singleLineCommentStart;
+	private final char structSeparator;
+	private final String catalogSeparator;
+	private final Set<String> commands = new HashSet<>();
+	private final String[] singleLineComments;
+	private final char[] singleLineCommentStart;
 
 	SQLTokensParser() {
 		this.structSeparator = sqlDialect.getStructSeparator();
@@ -49,11 +49,12 @@ class SQLTokensParser {
 		this.quoteStrings = sqlDialect.getIdentifierQuoteStrings();
 		this.singleLineComments = sqlDialect.getSingleLineComments();
 		this.singleLineCommentStart = new char[this.singleLineComments.length];
-		for (int i = 0; i < singleLineComments.length; i++) {
-			if (singleLineComments[i].isEmpty())
+		for (int i = 0;i < singleLineComments.length;i++) {
+			if (singleLineComments[i].isEmpty()) {
 				singleLineCommentStart[i] = 0;
-			else
+			} else {
 				singleLineCommentStart[i] = singleLineComments[i].charAt(0);
+			}
 		}
 	}
 
@@ -177,7 +178,7 @@ class SQLTokensParser {
 			String word = s.toString();
 			if (commands.contains(word.toUpperCase(Locale.ENGLISH))) {
 				s.setLength(0);
-				for (; fPos < fBefore.length(); fPos++) {
+				for (;fPos < fBefore.length();fPos++) {
 					fChar = fBefore.charAt(fPos);
 					if (fChar == '\n' || fChar == '\r') {
 						break;
@@ -292,11 +293,13 @@ class SQLTokensParser {
 	}
 
 	private static boolean contains(char[] array, char value) {
-		if (array == null || array.length == 0)
+		if (array == null || array.length == 0) {
 			return false;
+		}
 		for (char aChar : array) {
-			if (aChar == value)
+			if (aChar == value) {
 				return true;
+			}
 		}
 		return false;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlStep.java
@@ -31,7 +31,7 @@ import com.diffplug.spotless.Provisioner;
  */
 // https://stackoverflow.com/questions/14515994/convert-json-string-to-pretty-print-json-output-using-jackson
 // https://stackoverflow.com/questions/60891174/i-want-to-load-a-yaml-file-possibly-edit-the-data-and-then-dump-it-again-how
-public class JacksonYamlStep implements Serializable {
+public final class JacksonYamlStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	private static final String MAVEN_COORDINATE = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:";

--- a/lib/src/test/java/com/diffplug/spotless/RingBufferByteArrayOutputStreamTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/RingBufferByteArrayOutputStreamTest.java
@@ -143,7 +143,7 @@ class RingBufferByteArrayOutputStreamTest {
 
 	private static ByteWriteStrategy twoBytesAtATime() {
 		return (stream, bytes) -> {
-			for (int i = 0; i < bytes.length; i += 2) {
+			for (int i = 0;i < bytes.length;i += 2) {
 				stream.write(bytes, i, 2);
 			}
 		};
@@ -152,7 +152,7 @@ class RingBufferByteArrayOutputStreamTest {
 	private static ByteWriteStrategy oneAndThenTwoBytesAtATime() {
 		return (stream, bytes) -> {
 			int written = 0;
-			for (int i = 0; i + 3 < bytes.length; i += 3) {
+			for (int i = 0;i + 3 < bytes.length;i += 3) {
 				stream.write(bytes, i, 1);
 				stream.write(bytes, i + 1, 2);
 				written += 3;

--- a/lib/src/test/java/com/diffplug/spotless/npm/TimedLoggerTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/npm/TimedLoggerTest.java
@@ -208,7 +208,7 @@ class TimedLoggerTest {
 				if (event.arguments().length != arguments.length) {
 					return false;
 				}
-				for (int i = 0; i < arguments.length; i++) {
+				for (int i = 0;i < arguments.length;i++) {
 					if (!String.valueOf(event.arguments()[i]).equals(arguments[i])) {
 						return false;
 					}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AJacksonGradleConfig.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AJacksonGradleConfig.java
@@ -29,7 +29,7 @@ public abstract class AJacksonGradleConfig<T extends AJacksonGradleConfig> {
 	protected String version = JacksonJsonStep.defaultVersion();
 
 	// Make sure to call 'formatExtension.addStep(createStep());' in the extented constructors
-	public AJacksonGradleConfig(JacksonConfig jacksonConfig, FormatExtension formatExtension) {
+	protected AJacksonGradleConfig(JacksonConfig jacksonConfig, FormatExtension formatExtension) {
 		this.formatExtension = formatExtension;
 
 		this.jacksonConfig = jacksonConfig;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
@@ -54,7 +54,7 @@ public abstract class BaseGroovyExtension extends FormatExtension {
 		return new GrEclipseConfig(version, this);
 	}
 
-	public static class GrEclipseConfig {
+	public static final class GrEclipseConfig {
 		private final EquoBasedStepBuilder builder;
 		private final FormatExtension extension;
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
@@ -71,7 +71,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 
 	protected abstract boolean isScript();
 
-	public class DiktatConfig {
+	public final class DiktatConfig {
 		private final String version;
 		private FileSignature config;
 
@@ -97,7 +97,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 		}
 	}
 
-	public class KtfmtConfig {
+	public final class KtfmtConfig {
 		private final String version;
 		private final ConfigurableStyle configurableStyle = new ConfigurableStyle();
 		private KtfmtStep.Style style;
@@ -149,7 +149,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 		}
 	}
 
-	public class KtlintConfig {
+	public final class KtlintConfig {
 		private final String version;
 		private FileSignature editorConfigPath;
 		private Map<String, Object> editorConfigOverride;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -214,19 +214,15 @@ public class FormatExtension {
 	}
 
 	/** The files to be formatted = (target - targetExclude). */
-	protected FileCollection target, targetExclude;
+	protected FileCollection target;
+	protected FileCollection targetExclude;
 
 	/** The value from which files will be excluded if their content contain it. */
-	@Nullable protected String targetExcludeContentPattern = null;
+	@Nullable protected String targetExcludeContentPattern;
 
 	protected boolean isLicenseHeaderStep(FormatterStep formatterStep) {
 		String formatterStepName = formatterStep.getName();
-
-		if (formatterStepName.startsWith(LicenseHeaderStep.class.getName())) {
-			return true;
-		}
-
-		return false;
+		return formatterStepName.startsWith(LicenseHeaderStep.class.getName());
 	}
 
 	/**
@@ -378,7 +374,7 @@ public class FormatExtension {
 	 * step exists.
 	 */
 	protected int getExistingStepIdx(String stepName) {
-		for (int i = 0; i < steps.size(); ++i) {
+		for (int i = 0;i < steps.size();++i) {
 			if (steps.get(i).getName().equals(stepName)) {
 				return i;
 			}
@@ -566,7 +562,7 @@ public class FormatExtension {
 	 */
 	public class LicenseHeaderConfig {
 		LicenseHeaderStep builder;
-		Boolean updateYearWithLatest = null;
+		Boolean updateYearWithLatest;
 
 		public LicenseHeaderConfig named(String name) {
 			String existingStepName = builder.getName();
@@ -686,7 +682,7 @@ public class FormatExtension {
 
 		private Consumer<FormatterStep> replaceStep;
 
-		public NpmStepConfig(Project project, Consumer<FormatterStep> replaceStep) {
+		protected NpmStepConfig(Project project, Consumer<FormatterStep> replaceStep) {
 			this.project = requireNonNull(project);
 			this.replaceStep = requireNonNull(replaceStep);
 		}
@@ -1137,12 +1133,11 @@ public class FormatExtension {
 					task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
 				});
 		// create the apply task
-		TaskProvider<SpotlessApply> applyTask = spotless.project.getTasks().register(taskName, SpotlessApply.class,
+		return spotless.project.getTasks().register(taskName, SpotlessApply.class,
 				task -> {
 					task.dependsOn(spotlessTask);
 					task.init(spotlessTask.get());
 				});
-		return applyTask;
 	}
 
 	protected GradleException noDefaultTargetException() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -38,7 +38,7 @@ import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.spotless.Provisioner;
 
 /** Should be package-private. */
-class GradleProvisioner {
+final class GradleProvisioner {
 	private GradleProvisioner() {}
 
 	enum Policy {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.GroovySourceDirectorySet;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 
 public class GroovyExtension extends BaseGroovyExtension implements HasBuiltinDelimiterForLicense, JvmLang {
-	private boolean excludeJava = false;
+	private boolean excludeJava;
 	static final String NAME = "groovy";
 
 	@Inject
@@ -62,9 +62,7 @@ public class GroovyExtension extends BaseGroovyExtension implements HasBuiltinDe
 			}
 			target = getSources(getProject(),
 					message,
-					sourceSet -> {
-						return sourceSet.getExtensions().getByType(GroovySourceDirectorySet.class);
-					},
+					sourceSet -> sourceSet.getExtensions().getByType(GroovySourceDirectorySet.class),
 					file -> {
 						final String name = file.getName();
 						if (excludeJava) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -76,8 +76,8 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		final String[] importOrder;
 		final File importOrderFile;
 
-		boolean wildcardsLast = false;
-		boolean semanticSort = false;
+		boolean wildcardsLast;
+		boolean semanticSort;
 		Set<String> treatAsPackage = Set.of();
 		Set<String> treatAsClass = Set.of();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
@@ -62,11 +62,11 @@ public class JavascriptExtension extends FormatExtension {
 			extends NpmStepConfig<EslintBaseConfig<T>> {
 		Map<String, String> devDependencies = new LinkedHashMap<>();
 
-		@Nullable Object configFilePath = null;
+		@Nullable Object configFilePath;
 
-		@Nullable String configJs = null;
+		@Nullable String configJs;
 
-		public EslintBaseConfig(Project project, Consumer<FormatterStep> replaceStep,
+		protected EslintBaseConfig(Project project, Consumer<FormatterStep> replaceStep,
 				Map<String, String> devDependencies) {
 			super(project, replaceStep);
 			this.devDependencies.putAll(requireNonNull(devDependencies));

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
@@ -57,7 +57,7 @@ public class SpotlessDiagnoseTask extends DefaultTask {
 					// the file is misbehaved, so we'll write all its steps to DIAGNOSE_DIR
 					Path relative = srcRoot.relativize(file.toPath());
 					Path diagnoseFile = diagnoseRoot.resolve(relative);
-					for (int i = 0; i < padded.steps().size(); ++i) {
+					for (int i = 0;i < padded.steps().size();++i) {
 						Path path = Path.of(diagnoseFile + "." + padded.type().name().toLowerCase(Locale.ROOT) + i);
 						Files.createDirectories(path.getParent());
 						String version = padded.steps().get(i);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -23,7 +23,10 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SpotlessExtensionImpl extends SpotlessExtension {
-	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask, rootInstallPreHook;
+	final TaskProvider<?> rootCheckTask;
+	final TaskProvider<?> rootApplyTask;
+	final TaskProvider<?> rootDiagnoseTask;
+	final TaskProvider<?> rootInstallPreHook;
 
 	public SpotlessExtensionImpl(Project project) {
 		super(project);
@@ -35,9 +38,8 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.setGroup(TASK_GROUP);
 			task.setDescription(APPLY_DESCRIPTION);
 		});
-		rootDiagnoseTask = project.getTasks().register(EXTENSION + DIAGNOSE, task -> {
-			task.setGroup(TASK_GROUP); // no description on purpose
-		});
+		rootDiagnoseTask = project.getTasks().register(EXTENSION + DIAGNOSE, task ->
+			task.setGroup(TASK_GROUP));
 		rootInstallPreHook = project.getTasks().register(EXTENSION + INSTALL_GIT_PRE_PUSH_HOOK, SpotlessInstallPrePushHookTask.class, task -> {
 			task.setGroup(BUILD_SETUP_TASK_GROUP);
 			task.setDescription(INSTALL_GIT_PRE_PUSH_HOOK_DESCRIPTION);
@@ -66,7 +68,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			// clean removes the SpotlessCache, so we have to run after clean
 			task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
 		});
-		project.afterEvaluate(unused -> {
+		project.afterEvaluate(unused ->
 			spotlessTask.configure(task -> {
 				// now that the task is being configured, we execute our actions
 				for (Action<FormatExtension> lazyAction : formatExtension.lazyActions) {
@@ -74,8 +76,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 				}
 				// and now we'll setup the task
 				formatExtension.setupTask(task);
-			});
-		});
+			}));
 
 		// create the check and apply control tasks
 		TaskProvider<SpotlessApply> applyTask = tasks.register(taskName + APPLY, SpotlessApply.class, task -> {
@@ -84,9 +85,8 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.setEnabled(ideHook.path == null);
 			task.dependsOn(spotlessTask);
 		});
-		rootApplyTask.configure(task -> {
-			task.dependsOn(ideHook.path == null ? applyTask : spotlessTask);
-		});
+		rootApplyTask.configure(task ->
+			task.dependsOn(ideHook.path == null ? applyTask : spotlessTask));
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
 			SpotlessTaskImpl source = spotlessTask.get();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
@@ -29,7 +29,7 @@ public class SpotlessExtensionPredeclare extends SpotlessExtension {
 	public SpotlessExtensionPredeclare(Project project, GradleProvisioner.Policy policy) {
 		super(project);
 		getRegisterDependenciesTask().getTaskService().get().predeclaredProvisioner = policy.dedupingProvisioner(project);
-		project.afterEvaluate(unused -> {
+		project.afterEvaluate(unused ->
 			toSetup.forEach((name, formatExtension) -> {
 				for (Action<FormatExtension> lazyAction : formatExtension.lazyActions) {
 					lazyAction.execute(formatExtension);
@@ -37,8 +37,7 @@ public class SpotlessExtensionPredeclare extends SpotlessExtension {
 				getRegisterDependenciesTask().steps.addAll(formatExtension.steps);
 				// needed to fix Deemon memory leaks (#1194), but this line came from https://github.com/diffplug/spotless/pull/1206
 				LazyForwardingEquality.unlazy(getRegisterDependenciesTask().steps);
-			});
-		});
+			}));
 	}
 
 	@Override

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -185,7 +185,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 				}
 			});
 			StringBuilder builder = new StringBuilder();
-			builder.append("There were " + total.get() + " lint error(s), they must be fixed or suppressed.\n");
+			builder.append("There were ").append(total.get()).append(" lint error(s), they must be fixed or suppressed.\n");
 			for (Map.Entry<String, LinkedHashMap<String, List<Lint>>> lintsPerFile : allLints.entrySet()) {
 				for (Map.Entry<String, List<Lint>> stepLints : lintsPerFile.getValue().entrySet()) {
 					String stepName = stepLints.getKey();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -74,7 +74,7 @@ public class TypescriptExtension extends FormatExtension {
 
 		@Nullable TsConfigFileType configFileType = null;
 
-		@Nullable Object configFilePath = null;
+		@Nullable Object configFilePath;
 
 		private final Map<String, String> devDependencies;
 
@@ -196,7 +196,7 @@ public class TypescriptExtension extends FormatExtension {
 
 	public class TypescriptEslintConfig extends EslintBaseConfig<TypescriptEslintConfig> {
 
-		@Nullable Object typescriptConfigFilePath = null;
+		@Nullable Object typescriptConfigFilePath;
 
 		public TypescriptEslintConfig(Map<String, String> devDependencies) {
 			super(getProject(), TypescriptExtension.this::replaceStep, devDependencies);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
@@ -21,7 +21,7 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 abstract class BumpThisNumberIfACustomStepChangesTest extends GradleIntegrationHarness {
-	private boolean useConfigCache;
+	private final boolean useConfigCache;
 
 	BumpThisNumberIfACustomStepChangesTest(boolean useConfigCache) {
 		this.useConfigCache = useConfigCache;

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -184,7 +184,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 	@Test
 	void manyFiles() throws Exception {
 		List<File> testFiles = new ArrayList<>();
-		for (int i = 0; i < 9 + DiffMessageFormatter.MAX_FILES_TO_LIST - 1; ++i) {
+		for (int i = 0;i < 9 + DiffMessageFormatter.MAX_FILES_TO_LIST - 1;++i) {
 			String fileName = "%02d".formatted(i) + ".txt";
 			testFiles.add(setFile(fileName).toContent("1\r\n2\r\n"));
 		}
@@ -258,7 +258,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 	@Test
 	void manyManyFiles() throws Exception {
 		List<File> testFiles = new ArrayList<>();
-		for (int i = 0; i < 9 + DiffMessageFormatter.MAX_FILES_TO_LIST; ++i) {
+		for (int i = 0;i < 9 + DiffMessageFormatter.MAX_FILES_TO_LIST;++i) {
 			String fileName = "%02d".formatted(i) + ".txt";
 			testFiles.add(setFile(fileName).toContent("1\r\n2\r\n"));
 		}
@@ -323,7 +323,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 	@Test
 	void longFile() throws Exception {
 		StringBuilder builder = new StringBuilder();
-		for (int i = 0; i < 1000; ++i) {
+		for (int i = 0;i < 1000;++i) {
 			builder.append(i);
 			builder.append("\r\n");
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -147,9 +147,8 @@ public class GradleIntegrationHarness extends ResourceHarness {
 
 	/** Dumps the filtered file listing of the folder to the console. */
 	public String listFiles(Predicate<String> subpathsToInclude) {
-		return StringPrinter.buildString(printer -> iterateFiles(subpathsToInclude, (subPath, file) -> {
-			printer.println(subPath + " [" + getFileAttributes(file) + "]");
-		}));
+		return StringPrinter.buildString(printer -> iterateFiles(subpathsToInclude, (subPath, file) ->
+			printer.println(subPath + " [" + getFileAttributes(file) + "]")));
 	}
 
 	/** Dumps the file listing of the folder to the console. */

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
@@ -33,8 +33,12 @@ import com.diffplug.common.io.Files;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IdeHookTest extends GradleIntegrationHarness {
-	private String output, error;
-	private File dirty, clean, diverge, outofbounds;
+	private String output;
+	private String error;
+	private File dirty;
+	private File clean;
+	private File diverge;
+	private File outofbounds;
 
 	@BeforeEach
 	void before() throws IOException {
@@ -70,7 +74,7 @@ class IdeHookTest extends GradleIntegrationHarness {
 		StringBuilder output = new StringBuilder();
 		StringBuilder error = new StringBuilder();
 		try (Writer outputWriter = new StringPrinter(output::append).toWriter();
-				Writer errorWriter = new StringPrinter(error::append).toWriter();) {
+				Writer errorWriter = new StringPrinter(error::append).toWriter()) {
 			gradleRunner(configurationCache)
 					.withArguments(arguments)
 					.forwardStdOutput(outputWriter)

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IndentIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IndentIntegrationTest.java
@@ -83,8 +83,7 @@ class IndentIntegrationTest extends GradleIntegrationHarness {
 				"  }",
 				"}");
 		setFile("test.txt").toResource(resourceFile);
-		BuildResult result = gradleRunner().withArguments("spotlessApply").build();
-		return result;
+		return gradleRunner().withArguments("spotlessApply").build();
 	}
 
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.common.base.StringPrinter;
 
 class MultiProjectTest extends GradleIntegrationHarness {
-	private static int N = 100;
+	private static final int N = 100;
 
 	private void createNSubprojects() throws IOException {
-		for (int i = 0; i < N; ++i) {
+		for (int i = 0;i < N;++i) {
 			createSubproject(Integer.toString(i));
 		}
 		String settings = StringPrinter.buildString(printer -> {
-			for (int i = 0; i < N; ++i) {
+			for (int i = 0;i < N;++i) {
 				printer.println("include '" + i + "'");
 			}
 		});

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
@@ -52,13 +52,10 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
 		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
-			break;
-		case PRETTIER_VERSION_3:
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_3.clean");
-			break;
 		}
 	}
 
@@ -105,13 +102,10 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
 		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
-			break;
-		case PRETTIER_VERSION_3:
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_3.clean");
-			break;
 		}
 	}
 
@@ -140,14 +134,11 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 	void useJavaCommunityPlugin(String prettierVersion) throws IOException {
 		var prettierPluginJava = "";
 		var prettierConfigPluginsStr = "";
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
-			prettierPluginJava = "2.1.0"; // last version to support v2
-			break;
-		case PRETTIER_VERSION_3:
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
+			prettierPluginJava = "2.1.0";
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
 			prettierPluginJava = "2.3.0"; // latest to support v3
 			prettierConfigPluginsStr = "prettierConfig['plugins'] = ['prettier-plugin-java']";
-			break;
 		}
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -177,13 +168,10 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 	@ValueSource(strings = {PRETTIER_VERSION_2, PRETTIER_VERSION_3})
 	void useJavaCommunityPluginFileConfig(String prettierVersion) throws IOException {
 		var prettierPluginJava = "";
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
-			prettierPluginJava = "2.1.0"; // last version to support v2
-			break;
-		case PRETTIER_VERSION_3:
-			prettierPluginJava = "2.3.0"; // latest to support v3
-			break;
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
+			prettierPluginJava = "2.1.0";
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
+			prettierPluginJava = "2.3.0";
 		}
 		setFile(".prettierrc.yml").toResource("npm/prettier/config/.prettierrc_java_plugin.yml");
 		setFile("build.gradle").toLines(
@@ -235,14 +223,11 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 	void usePhpCommunityPlugin(String prettierVersion) throws IOException {
 		var prettierPluginPhp = "";
 		var prettierConfigPluginsStr = "";
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
-			prettierPluginPhp = "0.19.7"; // last version to support v2
-			break;
-		case PRETTIER_VERSION_3:
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
+			prettierPluginPhp = "0.19.7";
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
 			prettierPluginPhp = "0.20.1"; // latest to support v3
 			prettierConfigPluginsStr = "prettierConfig['plugins'] = ['@prettier/plugin-php']";
-			break;
 		}
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -280,17 +265,14 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 		var prettierPluginPhp = "";
 		var prettierConfigPluginsJavaStr = "";
 		var prettierConfigPluginsPhpStr = "";
-		switch (prettierVersion) {
-		case PRETTIER_VERSION_2:
+		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
 			prettierPluginJava = "2.1.0"; // last version to support v2
-			prettierPluginPhp = "0.19.7"; // last version to support v2
-			break;
-		case PRETTIER_VERSION_3:
+			prettierPluginPhp = "0.19.7";
+		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
 			prettierPluginJava = "2.3.0"; // latest to support v3
 			prettierPluginPhp = "0.20.1"; // latest to support v3
 			prettierConfigPluginsJavaStr = "prettierConfigJava['plugins'] = ['prettier-plugin-java']";
 			prettierConfigPluginsPhpStr = "prettierConfigPhp['plugins'] = ['@prettier/plugin-php']";
-			break;
 		}
 		setFile("build.gradle").toLines(
 				"plugins {",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ToggleOffOnTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ToggleOffOnTest.java
@@ -21,7 +21,7 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 abstract class ToggleOffOnTest extends GradleIntegrationHarness {
-	private boolean useConfigCache;
+	private final boolean useConfigCache;
 
 	ToggleOffOnTest(boolean useConfigCache) {
 		this.useConfigCache = useConfigCache;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -61,7 +61,7 @@ public class ArtifactResolver {
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
 	public Set<File> resolve(boolean withTransitives, Collection<String> mavenCoordinates) {
-		Collection<Exclusion> excludeTransitive = new ArrayList<Exclusion>(1);
+		Collection<Exclusion> excludeTransitive = new ArrayList<>(1);
 		if (!withTransitives) {
 			excludeTransitive.add(EXCLUDE_ALL_TRANSITIVES);
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FileLocator.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FileLocator.java
@@ -37,7 +37,9 @@ public class FileLocator {
 	static final String TMP_RESOURCE_FILE_PREFIX = "spotless-resource-";
 
 	private final ResourceManager resourceManager;
-	private final File baseDir, buildDir, dataDir;
+	private final File baseDir;
+	private final File buildDir;
+	private final File dataDir;
 
 	public FileLocator(ResourceManager resourceManager, File baseDir, File buildDir) {
 		this.resourceManager = Objects.requireNonNull(resourceManager);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -96,7 +96,7 @@ public abstract class FormatterFactory {
 		List<FormatterStep> formatterSteps = factories.stream()
 				.filter(Objects::nonNull) // all unrecognized steps from XML config appear as nulls in the list
 				.map(factory -> factory.newFormatterStep(stepConfig))
-				.collect(Collectors.toCollection(() -> new ArrayList<FormatterStep>()));
+				.collect(Collectors.toCollection(ArrayList::new));
 		if (toggle != null) {
 			List<FormatterStep> formatterStepsBeforeToggle = formatterSteps;
 			formatterSteps = List.of(toggle.createFence().preserveWithin(formatterStepsBeforeToggle));

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ImpactedFilesTracker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ImpactedFilesTracker.java
@@ -19,9 +19,9 @@ package com.diffplug.spotless.maven;
  * Tracks the number of processed files, typically by a single Formatter for a whole repository
  */
 class ImpactedFilesTracker {
-	protected int nbskippedAsCleanCache = 0;
-	protected int nbCheckedButAlreadyClean = 0;
-	protected int nbCleaned = 0;
+	protected int nbskippedAsCleanCache;
+	protected int nbCheckedButAlreadyClean;
+	protected int nbCleaned;
 
 	/**
 	 * Some cache mechanism may indicate some content is clean, without having to execute the cleaning process

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
@@ -18,7 +18,7 @@ package com.diffplug.spotless.maven;
 import com.diffplug.spotless.Provisioner;
 
 /** Maven integration for Provisioner. */
-public class MavenProvisioner {
+public final class MavenProvisioner {
 	private MavenProvisioner() {}
 
 	public static Provisioner create(ArtifactResolver artifactResolver) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -40,7 +40,7 @@ import com.diffplug.common.annotations.VisibleForTesting;
 
 import jakarta.annotation.Nullable;
 
-class FileIndex {
+final class FileIndex {
 
 	private static final String SEPARATOR = " ";
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
-class NoopChecker implements UpToDateChecker {
+final class NoopChecker implements UpToDateChecker {
 
 	private NoopChecker() {}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/ObjectDigestOutputStream.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/ObjectDigestOutputStream.java
@@ -22,7 +22,7 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-class ObjectDigestOutputStream extends ObjectOutputStream {
+final class ObjectDigestOutputStream extends ObjectOutputStream {
 
 	private final MessageDigest messageDigest;
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
@@ -33,7 +33,7 @@ import com.diffplug.spotless.Formatter;
  *    <li>Formatter instances created according to the POM configuration</li>
  * </ol>
  */
-class PluginFingerprint {
+final class PluginFingerprint {
 
 	private static final String SPOTLESS_PLUGIN_KEY = "com.diffplug.spotless:spotless-maven-plugin";
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -34,7 +34,7 @@ public class ImportOrder implements FormatterStepFactory {
 	private String order;
 
 	@Parameter
-	private boolean wildcardsLast = false;
+	private boolean wildcardsLast;
 
 	/**
 	 * Whether imports should be sorted based on semantics (i.e. sorted by package,
@@ -44,7 +44,7 @@ public class ImportOrder implements FormatterStepFactory {
 	 * lexicographically.
 	 */
 	@Parameter
-	private boolean semanticSort = false;
+	private boolean semanticSort;
 
 	/**
 	 * The prefixes that should be treated as packages for

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
@@ -28,10 +28,10 @@ public class Gson implements FormatterStepFactory {
 	int indentSpaces = Json.DEFAULT_INDENTATION;
 
 	@Parameter
-	boolean sortByKeys = false;
+	boolean sortByKeys;
 
 	@Parameter
-	boolean escapeHtml = false;
+	boolean escapeHtml;
 
 	@Parameter
 	String version = GsonStep.DEFAULT_VERSION;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
@@ -49,18 +49,15 @@ public abstract class AbstractNpmFormatterStepFactory implements FormatterStepFa
 	private String npmInstallCache;
 
 	protected File npm(FormatterStepConfig stepConfig) {
-		File npm = npmExecutable != null ? stepConfig.getFileLocator().locateFile(npmExecutable) : null;
-		return npm;
+		return npmExecutable != null ? stepConfig.getFileLocator().locateFile(npmExecutable) : null;
 	}
 
 	protected File node(FormatterStepConfig stepConfig) {
-		File node = nodeExecutable != null ? stepConfig.getFileLocator().locateFile(nodeExecutable) : null;
-		return node;
+		return nodeExecutable != null ? stepConfig.getFileLocator().locateFile(nodeExecutable) : null;
 	}
 
 	protected File npmrc(FormatterStepConfig stepConfig) {
-		File npmrc = this.npmrc != null ? stepConfig.getFileLocator().locateFile(this.npmrc) : null;
-		return npmrc;
+		return this.npmrc != null ? stepConfig.getFileLocator().locateFile(this.npmrc) : null;
 	}
 
 	protected File buildDir(FormatterStepConfig stepConfig) {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/IdeHookTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/IdeHookTest.java
@@ -25,8 +25,12 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.ProcessRunner;
 
 class IdeHookTest extends MavenIntegrationHarness {
-	private String output, error;
-	private File dirty, clean, diverge, outofbounds;
+	private String output;
+	private String error;
+	private File dirty;
+	private File clean;
+	private File diverge;
+	private File outofbounds;
 
 	@BeforeEach
 	void before() throws IOException {
@@ -44,7 +48,6 @@ class IdeHookTest extends MavenIntegrationHarness {
 		dirty = setFile("DIRTY.md").toContent("World");
 		clean = setFile("CLEAN.md").toContent("Mars");
 		outofbounds = setFile("OUTOFBOUNDS.md").toContent("Mars");
-		;
 	}
 
 	private void runWith(String... arguments) throws IOException, InterruptedException {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
@@ -359,7 +360,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	protected StringSelfie expectSelfieErrorMsg(ProcessRunner.Result result) {
 		String concatenatedError = result.stdOutUtf8().lines()
 				.map(line -> line.startsWith(ERROR_PREFIX) ? line.substring(ERROR_PREFIX.length()) : null)
-				.filter(line -> line != null)
+				.filter(Objects::nonNull)
 				.collect(Collectors.joining("\n"));
 
 		String sanitizedVersion = concatenatedError.replaceFirst("com\\.diffplug\\.spotless:spotless-maven-plugin:([^:]+):", "com.diffplug.spotless:spotless-maven-plugin:VERSION:");

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
@@ -33,7 +33,7 @@ import com.diffplug.spotless.ProcessRunner;
  * Harness for running a Maven build, same idea as the
  * <a href="https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html">GradleRunner from the Gradle testkit</a>.
  */
-public class MavenRunner {
+public final class MavenRunner {
 	public static MavenRunner create() {
 		return new MavenRunner();
 	}
@@ -42,8 +42,8 @@ public class MavenRunner {
 
 	private File projectDir;
 	private String[] args;
-	private Map<String, String> environment = new HashMap<>();
-	private Map<String, String> systemProperties = new HashMap<>();
+	private final Map<String, String> environment = new HashMap<>();
+	private final Map<String, String> systemProperties = new HashMap<>();
 	private ProcessRunner runner;
 
 	public MavenRunner withProjectDir(File projectDir) {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
@@ -177,7 +177,7 @@ class MultiModuleProjectTest extends MavenIntegrationHarness {
 		}
 	}
 
-	static class SubProjectFile {
+	static final class SubProjectFile {
 
 		private final String from;
 		private final String to;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpecificFilesTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpecificFilesTest.java
@@ -85,10 +85,11 @@ public class SpecificFilesTest extends MavenIntegrationHarness {
 	@Test
 	void regexp() throws IOException, InterruptedException {
 		String pattern;
-		if (isOnWindows())
+		if (isOnWindows()) {
 			pattern = "\".*\\\\src\\\\main\\\\java\\\\test(1|3).java\"";
-		else
+		} else {
 			pattern = "'.*/src/main/java/test(1|3).java'";
+		}
 		integration(pattern, true, false, true);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -245,7 +245,7 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 
 	private List<File> writeFiles(String resource, String suffix, int count) throws IOException {
 		List<File> result = new ArrayList<>(count);
-		for (int i = 0; i < count; i++) {
+		for (int i = 0;i < count;i++) {
 			String path = "src/main/java/test_" + suffix + "_" + i + ".java";
 			File file = setFile(path).toResource(resource);
 			result.add(file);

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,14 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.diffplug.spotless.openrewrite.SanityCheck
+displayName: Apply all Java & Gradle best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+tags:
+  - java
+  - gradle
+  - static-analysis
+  - cleanup
+recipeList:
+  - org.openrewrite.java.format.NoWhitespaceBefore
+  # - org.openrewrite.staticanalysis.UnnecessaryThrows # bug
+---

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -178,7 +178,7 @@ public class ResourceHarness {
 		return new ReadAsserter(file);
 	}
 
-	public static class ReadAsserter {
+	public static final class ReadAsserter {
 		private final File file;
 
 		private ReadAsserter(File file) {
@@ -223,7 +223,7 @@ public class ResourceHarness {
 		return new WriteAsserter(newFile(path));
 	}
 
-	public static class WriteAsserter {
+	public static final class WriteAsserter {
 		private File file;
 
 		private WriteAsserter(File file) {
@@ -240,16 +240,14 @@ public class ResourceHarness {
 		}
 
 		public File toContent(String content, Charset charset) {
-			ThrowingEx.run(() -> {
-				Files.write(file.toPath(), content.getBytes(charset));
-			});
+			ThrowingEx.run(() ->
+				Files.write(file.toPath(), content.getBytes(charset)));
 			return file;
 		}
 
 		public File toResource(String path) {
-			ThrowingEx.run(() -> {
-				Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8));
-			});
+			ThrowingEx.run(() ->
+				Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8)));
 			return file;
 		}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -25,7 +25,7 @@ import com.diffplug.selfie.Selfie;
 import com.diffplug.selfie.StringSelfie;
 
 /** An api for testing a {@code FormatterStep} that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
-public class StepHarness extends StepHarnessBase {
+public final class StepHarness extends StepHarnessBase {
 	private StepHarness(Formatter formatter, RoundTrip roundTrip) {
 		super(formatter, roundTrip);
 	}

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import com.diffplug.selfie.StringSelfie;
 
 /** An api for testing a {@code FormatterStep} that depends on the File path. */
-public class StepHarnessWithFile extends StepHarnessBase {
+public final class StepHarnessWithFile extends StepHarnessBase {
 	private final ResourceHarness harness;
 
 	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter, RoundTrip roundTrip) {

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -143,9 +143,7 @@ public class TestProvisioner {
 		return mavenCentral.get();
 	}
 
-	private static final Supplier<Provisioner> mavenCentral = Suppliers.memoize(() -> {
-		return caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral()));
-	});
+	private static final Supplier<Provisioner> mavenCentral = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
 
 	/** Creates a Provisioner for the local maven repo for development purpose. */
 	public static Provisioner mavenLocal() {
@@ -159,9 +157,7 @@ public class TestProvisioner {
 		return snapshots.get();
 	}
 
-	private static final Supplier<Provisioner> snapshots = () -> createWithRepositories(repo -> {
-		repo.maven(setup -> {
-			setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots");
-		});
-	});
+	private static final Supplier<Provisioner> snapshots = () -> createWithRepositories(repo ->
+		repo.maven(setup ->
+			setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
 }

--- a/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
@@ -42,7 +42,7 @@ class JvmTest {
 
 	@Test
 	void supportAdd() {
-		Integer differentVersions[] = {0, 1, 2};
+		Integer[] differentVersions = {0, 1, 2};
 		Arrays.asList(differentVersions).forEach(v -> testSupport.add(v + Jvm.version(), v.toString()));
 		Arrays.asList(differentVersions).forEach(v -> assertThat(testSupport.toString()).contains("Version %d".formatted(v)));
 		assertThat(testSupport.toString()).contains("%s alternatives".formatted(TEST_NAME));
@@ -51,9 +51,8 @@ class JvmTest {
 	@ParameterizedTest(name = "{index} {1}")
 	@MethodSource
 	void supportAddFailsFor(Consumer<Jvm.Support<String>> configuration, String nameNotUsed) {
-		assertThrows(IllegalArgumentException.class, () -> {
-			configuration.accept(testSupport);
-		});
+		assertThrows(IllegalArgumentException.class, () ->
+			configuration.accept(testSupport));
 	}
 
 	private static Stream<Arguments> supportAddFailsFor() {
@@ -76,11 +75,10 @@ class JvmTest {
 		testSupport.assertFormatterSupported("0.1");
 
 		Exception expected = new Exception("Some test exception");
-		Exception actual = assertThrows(Exception.class, () -> {
+		Exception actual = assertThrows(Exception.class, () ->
 			testSupport.suggestLaterVersionOnError("0.0", unused -> {
 				throw expected;
-			}).apply("");
-		});
+			}).apply(""));
 		assertEquals(expected, actual);
 	}
 
@@ -94,34 +92,30 @@ class JvmTest {
 		assertNull(testSupport.getRecommendedFormatterVersion(), "No formatter version is supported");
 
 		for (String fmtVersion : Arrays.asList("1.2", "1.2.3", "1.2-SNAPSHOT", "1.2.3-SNAPSHOT")) {
-			String proposal = assertThrows(Lint.ShortcutException.class, () -> {
-				testSupport.assertFormatterSupported(fmtVersion);
-			}).getLints().get(0).getDetail();
+			String proposal = assertThrows(Lint.ShortcutException.class, () ->
+				testSupport.assertFormatterSupported(fmtVersion)).getLints().get(0).getDetail();
 			assertThat(proposal).contains(String.format("on JVM %d", Jvm.version()));
 			assertThat(proposal).contains("%s %s requires JVM %d+".formatted(TEST_NAME, fmtVersion, higherJvmVersion));
 			assertThat(proposal).contains("try %s alternatives".formatted(TEST_NAME));
 
-			proposal = assertThrows(Exception.class, () -> {
+			proposal = assertThrows(Exception.class, () ->
 				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
 					throw testException;
-				}).apply("");
-			}).getMessage();
+				}).apply("")).getMessage();
 			assertThat(proposal).contains(String.format("on JVM %d", Jvm.version()));
 			assertThat(proposal).contains("%s %s requires JVM %d+".formatted(TEST_NAME, fmtVersion, higherJvmVersion));
 			assertThat(proposal).contains("try %s alternatives".formatted(TEST_NAME));
 		}
 
 		for (String fmtVersion : Arrays.asList("1.2.4", "2", "1.2.5-SNAPSHOT")) {
-			String proposal = assertThrows(Lint.ShortcutException.class, () -> {
-				testSupport.assertFormatterSupported(fmtVersion);
-			}).getLints().get(0).getDetail();
+			String proposal = assertThrows(Lint.ShortcutException.class, () ->
+				testSupport.assertFormatterSupported(fmtVersion)).getLints().get(0).getDetail();
 			assertThat(proposal).contains("%s %s requires JVM %d+".formatted(TEST_NAME, fmtVersion, higherJvmVersion + 1));
 
-			proposal = assertThrows(Exception.class, () -> {
+			proposal = assertThrows(Exception.class, () ->
 				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
 					throw testException;
-				}).apply("");
-			}).getMessage();
+				}).apply("")).getMessage();
 			assertThat(proposal).contains("%s %s requires JVM %d+".formatted(TEST_NAME, fmtVersion, higherJvmVersion + 1));
 		}
 	}
@@ -135,11 +129,10 @@ class JvmTest {
 		for (String fmtVersion : Arrays.asList("0", "1", "1.9", "1.9-SNAPSHOT")) {
 			testSupport.assertFormatterSupported(fmtVersion);
 
-			String proposal = assertThrows(Exception.class, () -> {
+			String proposal = assertThrows(Exception.class, () ->
 				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
 					throw new Exception("Some test exception");
-				}).apply("");
-			}).getMessage();
+				}).apply("")).getMessage();
 			assertThat(proposal.replace("\r", "")).isEqualTo("My Test Formatter " + fmtVersion + " is currently being used, but outdated.\n" +
 					"My Test Formatter 2 is the recommended version, which may have fixed this problem.\n" +
 					"My Test Formatter 2 requires JVM " + requiredJvm + "+.");
@@ -153,11 +146,10 @@ class JvmTest {
 		testSupport.add(higherJvm, "2");
 		testSupport.add(higherJvm + 1, "3");
 		for (String fmtVersion : Arrays.asList("1", "1.0")) {
-			String proposal = assertThrows(Exception.class, () -> {
+			String proposal = assertThrows(Exception.class, () ->
 				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
 					throw new Exception("Some test exception");
-				}).apply("");
-			}).getMessage();
+				}).apply("")).getMessage();
 			assertThat(proposal).contains(String.format("on JVM %d", Jvm.version()));
 			assertThat(proposal).contains("limits you to %s %s".formatted(TEST_NAME, "1"));
 			assertThat(proposal).contains("upgrade your JVM to %d+".formatted(higherJvm));
@@ -172,11 +164,10 @@ class JvmTest {
 			testSupport.assertFormatterSupported(fmtVersion);
 
 			Exception testException = new Exception("Some test exception");
-			Exception exception = assertThrows(Exception.class, () -> {
+			Exception exception = assertThrows(Exception.class, () ->
 				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
 					throw testException;
-				}).apply("");
-			});
+				}).apply(""));
 			assertEquals(testException, exception);
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
@@ -116,7 +116,7 @@ class PaddedCellTest {
 	void cycleOrder() {
 		BiConsumer<String, String> testCase = (unorderedStr, canonical) -> {
 			List<String> unordered = Arrays.asList(unorderedStr.split(","));
-			for (int i = 0; i < unordered.size(); ++i) {
+			for (int i = 0;i < unordered.size();++i) {
 				// try every rotation of the list
 				Collections.rotate(unordered, 1);
 				PaddedCell result = CYCLE.create(rootFolder, unordered);

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IdeaStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IdeaStepTest.java
@@ -104,7 +104,7 @@ class IdeaStepTest extends ResourceHarness {
 				"formatting was applied to clean file");
 	}
 
-	private File buildDir = null;
+	private File buildDir;
 
 	protected File buildDir() {
 		if (this.buildDir == null) {

--- a/testlib/src/test/java/com/diffplug/spotless/gherkin/GherkinUtilsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/gherkin/GherkinUtilsStepTest.java
@@ -97,7 +97,7 @@ public class GherkinUtilsStepTest {
 	@Test
 	public void equality() {
 		new SerializableEqualityTester() {
-			int spaces = 0;
+			int spaces;
 
 			@Override
 			protected void setupTest(API api) {

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -138,7 +138,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 		new SerializableEqualityTester() {
 			String version = "1.10.0";
 			String style = "";
-			boolean reflowLongStrings = false;
+			boolean reflowLongStrings;
 
 			@Override
 			protected void setupTest(API api) {
@@ -170,7 +170,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 			String groupArtifact = GoogleJavaFormatStep.defaultGroupArtifact();
 			String version = "1.11.0";
 			String style = "";
-			boolean reflowLongStrings = false;
+			boolean reflowLongStrings;
 
 			@Override
 			protected void setupTest(API api) {

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -72,7 +72,7 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 		new SerializableEqualityTester() {
 			String version = "1.1.0";
 			String style = "";
-			boolean formatJavadoc = false;
+			boolean formatJavadoc;
 
 			@Override
 			protected void setupTest(API api) {

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonFormatterStepCommonTests.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonFormatterStepCommonTests.java
@@ -75,7 +75,7 @@ public abstract class JsonFormatterStepCommonTests {
 	@Test
 	void equality() {
 		new SerializableEqualityTester() {
-			int spaces = 0;
+			int spaces;
 
 			@Override
 			protected void setupTest(API api) {

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -105,7 +105,7 @@ class JsonSimpleStepTest {
 	@Test
 	void equality() {
 		new SerializableEqualityTester() {
-			int spaces = 0;
+			int spaces;
 
 			@Override
 			protected void setupTest(API api) {

--- a/testlib/src/test/java/com/diffplug/spotless/npm/JsonWriterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/JsonWriterTest.java
@@ -28,7 +28,7 @@ import com.diffplug.spotless.ResourceHarness;
 
 class JsonWriterTest extends ResourceHarness {
 
-	private JsonWriter jsonWriter = new JsonWriter();
+	private final JsonWriter jsonWriter = new JsonWriter();
 
 	@Test
 	void itWritesAValidEmptyObject() {

--- a/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
@@ -39,7 +39,7 @@ public abstract class NpmFormatterStepCommonTests extends ResourceHarness {
 		return new NpmrcResolver().tryFind().orElse(null);
 	}
 
-	private File buildDir = null;
+	private File buildDir;
 
 	protected File buildDir() {
 		if (this.buildDir == null) {
@@ -48,7 +48,7 @@ public abstract class NpmFormatterStepCommonTests extends ResourceHarness {
 		return this.buildDir;
 	}
 
-	private File projectDir = null;
+	private File projectDir;
 
 	protected File projectDir() {
 		if (this.projectDir == null) {

--- a/testlib/src/test/java/com/diffplug/spotless/npm/ShadowCopyTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/ShadowCopyTest.java
@@ -146,7 +146,7 @@ class ShadowCopyTest extends ResourceHarness {
 		List<File> actualContent = filesInAlphabeticalOrder(actual);
 		List<File> expectedContent = filesInAlphabeticalOrder(expected);
 
-		for (int i = 0; i < expectedContent.size(); i++) {
+		for (int i = 0;i < expectedContent.size();i++) {
 			assertAllFilesAreEqualButNotSameAbsolutePath(expectedContent.get(i), actualContent.get(i));
 		}
 	}
@@ -181,7 +181,7 @@ class ShadowCopyTest extends ResourceHarness {
 		// returns a string of length containing characters a-z, A-Z, 0-9
 
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < length; i++) {
+		for (int i = 0;i < length;i++) {
 			sb.append(CHARS[random.nextInt(CHARS.length)]);
 		}
 		return sb.toString();

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -57,16 +57,15 @@ class ScalaFmtStepTest extends ResourceHarness {
 	@Test
 	void behaviorConfigFileVersionDoesnotMatchLibrary() {
 		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
-		Assertions.assertThatThrownBy(() -> {
-			step.format("", new File(""));
-		}).cause().message().contains("Spotless is using 3.0.0 but the config file declares 3.8.1. Both must match. Update the version declared in the plugin's settings and/or the config file.");
+		Assertions.assertThatThrownBy(() ->
+			step.format("", new File(""))).cause().message().contains("Spotless is using 3.0.0 but the config file declares 3.8.1. Both must match. Update the version declared in the plugin's settings and/or the config file.");
 	}
 
 	@Test
 	void equality() {
 		new SerializableEqualityTester() {
 			String version = "3.6.1";
-			File configFile = null;
+			File configFile;
 
 			@Override
 			protected void setupTest(API api) {
@@ -94,8 +93,7 @@ class ScalaFmtStepTest extends ResourceHarness {
 	void invalidConfiguration() {
 		File invalidConfFile = createTestFile("scala/scalafmt/scalafmt.invalid.conf");
 		Provisioner provisioner = TestProvisioner.mavenCentral();
-		Assertions.assertThatThrownBy(() -> {
-			ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile).format("", new File(""));
-		}).cause().message().contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
+		Assertions.assertThatThrownBy(() ->
+			ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile).format("", new File(""))).cause().message().contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
 	}
 }


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
