### PR TITLE
Add `error-prone.picnic.tech`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 apply from: rootProject.file('gradle/java-publish.gradle')
 apply from: rootProject.file('gradle/changelog.gradle')
 allprojects {
+	apply from: rootProject.file('gradle/error-prone.gradle')
 	apply from: rootProject.file('gradle/rewrite.gradle')
 	apply from: rootProject.file('gradle/spotless.gradle')
 }

--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -1,0 +1,263 @@
+import static java.lang.System.getenv
+
+apply plugin: 'net.ltgt.errorprone'
+
+dependencies {
+	errorprone('com.google.errorprone:error_prone_core:2.42.0')
+	errorprone('tech.picnic.error-prone-support:error-prone-contrib:0.25.0')
+	errorprone('tech.picnic.error-prone-support:refaster-runner:0.25.0')
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.errorprone {
+		allErrorsAsWarnings = true
+		disableWarningsInGeneratedCode = true
+		disable(
+				// avoid
+				'StaticImport',
+				// bug
+				'AddNullMarkedToPackageInfo',
+				'Slf4jLogStatement',
+				'Slf4jLogStatement',
+				)
+		// dev opt-in
+		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
+			// apply
+			errorproneArgs.addAll(
+					'-XepPatchLocation:IN_PLACE',
+					'-XepPatchChecks:' +
+					'AddNullMarkedToPackageInfo,' +
+					'AlwaysThrows,' +
+					'AmbiguousJsonCreator,' +
+					'AndroidInjectionBeforeSuper,' +
+					'ArrayEquals,' +
+					'ArrayFillIncompatibleType,' +
+					'ArrayHashCode,' +
+					'ArrayToString,' +
+					'ArraysAsListPrimitiveArray,' +
+					'AssertJNullnessAssertion,' +
+					'AsyncCallableReturnsNull,' +
+					'AsyncFunctionReturnsNull,' +
+					'AutoValueBuilderDefaultsInConstructor,' +
+					'AutoValueConstructorOrderChecker,' +
+					'AutowiredConstructor,' +
+					'BadAnnotationImplementation,' +
+					'BadShiftAmount,' +
+					'BanJNDI,' +
+					'BoxedPrimitiveEquality,' +
+					'BundleDeserializationCast,' +
+					'CanonicalAnnotationSyntax,' +
+					'CanonicalClassNameUsage,' +
+					'ChainingConstructorIgnoresParameter,' +
+					'CheckNotNullMultipleTimes,' +
+					'CheckReturnValue,' +
+					'ClassCastLambdaUsage,' +
+					'CollectionIncompatibleType,' +
+					'CollectionToArraySafeParameter,' +
+					'CollectorMutability,' +
+					'ComparableType,' +
+					'ComparingThisWithNull,' +
+					'ComparisonOutOfRange,' +
+					'CompatibleWithAnnotationMisuse,' +
+					'CompileTimeConstant,' +
+					'ComputeIfAbsentAmbiguousReference,' +
+					'ConditionalExpressionNumericPromotion,' +
+					'ConstantNaming,' +
+					'ConstantOverflow,' +
+					'DaggerProvidesNull,' +
+					'DangerousLiteralNull,' +
+					'DeadException,' +
+					'DeadThread,' +
+					'DefaultCharset,' +
+					'DereferenceWithNullBranch,' +
+					'DirectReturn,' +
+					'DiscardedPostfixExpression,' +
+					'DoNotCall,' +
+					'DoNotMock,' +
+					'DoubleBraceInitialization,' +
+					'DuplicateMapKeys,' +
+					'DurationFrom,' +
+					'DurationGetTemporalUnit,' +
+					'DurationTemporalUnit,' +
+					'DurationToLongTimeUnit,' +
+					'EagerStringFormatting,' +
+					'EmptyMethod,' +
+					'EmptyMonoZip,' +
+					'EqualsHashCode,' +
+					'EqualsNaN,' +
+					'EqualsNull,' +
+					'EqualsReference,' +
+					'EqualsWrongThing,' +
+					'ExplicitArgumentEnumeration,' +
+					'ExplicitEnumOrdering,' +
+					'FloggerFormatString,' +
+					'FloggerLogString,' +
+					'FloggerLogVarargs,' +
+					'FloggerSplitLogStatement,' +
+					'FluxFlatMapUsage,' +
+					'FluxImplicitBlock,' +
+					'ForOverride,' +
+					'FormatString,' +
+					'FormatStringAnnotation,' +
+					'FormatStringConcatenation,' +
+					'FromTemporalAccessor,' +
+					'FunctionalInterfaceMethodChanged,' +
+					'FunctionalInterfaceMethodChanged,' +
+					'FuturesGetCheckedIllegalExceptionType,' +
+					'FuzzyEqualsShouldNotBeUsedInEqualsMethod,' +
+					'GetClassOnAnnotation,' +
+					'GetClassOnClass,' +
+					'GuardedBy,' +
+					'GuiceAssistedInjectScoping,' +
+					'GuiceAssistedParameters,' +
+					'GuiceInjectOnFinalField,' +
+					'HashtableContains,' +
+					'IdentityBinaryExpression,' +
+					'IdentityConversion,' +
+					'IdentityHashMapBoxing,' +
+					'Immutable,' +
+					'ImmutableEnumChecker,' +
+					'ImmutablesSortedSetComparator,' +
+					'ImpossibleNullComparison,' +
+					'Incomparable,' +
+					'IncompatibleArgumentType,' +
+					'IncompatibleModifiers,' +
+					'IndexOfChar,' +
+					'InexactVarargsConditional,' +
+					'InfiniteRecursion,' +
+					'InjectMoreThanOneScopeAnnotationOnClass,' +
+					'InjectOnMemberAndConstructor,' +
+					'InlineMeValidator,' +
+					'InstantTemporalUnit,' +
+					'InvalidJavaTimeConstant,' +
+					'InvalidPatternSyntax,' +
+					'InvalidTimeZoneID,' +
+					'InvalidZoneId,' +
+					'IsInstanceIncompatibleType,' +
+					'IsInstanceLambdaUsage,' +
+					'IsInstanceOfClass,' +
+					'IsLoggableTagLength,' +
+					'JUnit3TestNotRun,' +
+					'JUnit4ClassAnnotationNonStatic,' +
+					'JUnit4SetUpNotRun,' +
+					'JUnit4TearDownNotRun,' +
+					'JUnit4TestNotRun,' +
+					'JUnit4TestsNotRunWithinEnclosed,' +
+					'JUnitAssertSameCheck,' +
+					'JUnitClassModifiers,' +
+					'JUnitMethodDeclaration,' +
+					'JUnitNullaryParameterizedTestDeclaration,' +
+					'JUnitParameterMethodNotFound,' +
+					'JUnitValueSource,' +
+					'JavaxInjectOnAbstractMethod,' +
+					'JodaToSelf,' +
+					'LenientFormatStringValidation,' +
+					'LexicographicalAnnotationAttributeListing,' +
+					'LexicographicalAnnotationListing,' +
+					'LiteByteStringUtf8,' +
+					'LocalDateTemporalAmount,' +
+					'LockOnBoxedPrimitive,' +
+					'LoopConditionChecker,' +
+					'LossyPrimitiveCompare,' +
+					'MathRoundIntLong,' +
+					'MislabeledAndroidString,' +
+					'MisleadingEmptyVarargs,' +
+					'MisleadingEscapedSpace,' +
+					'MisplacedScopeAnnotations,' +
+					'MissingOverride,' +
+					'MissingSuperCall,' +
+					'MissingTestCall,' +
+					'MisusedDayOfYear,' +
+					'MisusedWeekYear,' +
+					'MixedDescriptors,' +
+					'MockitoMockClassReference,' +
+					'MockitoStubbing,' +
+					'MockitoUsage,' +
+					'ModifyingCollectionWithItself,' +
+					'MongoDBTextFilterUsage,' +
+					'MoreThanOneInjectableConstructor,' +
+					'MustBeClosedChecker,' +
+					'NCopiesOfChar,' +
+					'NestedOptionals,' +
+					'NestedPublishers,' +
+					'NoCanIgnoreReturnValueOnClasses,' +
+					'NonCanonicalStaticImport,' +
+					'NonEmptyMono,' +
+					'NonFinalCompileTimeConstant,' +
+					'NonRuntimeAnnotation,' +
+					'NonStaticImport,' +
+					'NullArgumentForNonNullParameter,' +
+					'NullTernary,' +
+					'NullableOnContainingClass,' +
+					'OptionalEquality,' +
+					'OptionalMapUnusedValue,' +
+					'OptionalOfRedundantMethod,' +
+					'OptionalOrElseGet,' +
+					'OverlappingQualifierAndScopeAnnotation,' +
+					'OverridesJavaxInjectableMethod,' +
+					'PackageInfo,' +
+					'ParametersButNotParameterized,' +
+					'ParcelableCreator,' +
+					'PeriodFrom,' +
+					'PeriodGetTemporalUnit,' +
+					'PeriodTimeMath,' +
+					'PreconditionsInvalidPlaceholder,' +
+					'PrimitiveComparison,' +
+					'PrivateSecurityContractProtoAccess,' +
+					'ProtoBuilderReturnValueIgnored,' +
+					'ProtoStringFieldReferenceEquality,' +
+					'ProtoTruthMixedDescriptors,' +
+					'ProtocolBufferOrdinal,' +
+					'ProvidesMethodOutsideOfModule,' +
+					'RandomCast,' +
+					'RandomModInteger,' +
+					'RectIntersectReturnValueIgnored,' +
+					'RedundantSetterCall,' +
+					'RedundantStringConversion,' +
+					'RedundantStringEscape,' +
+					'RefasterAnyOfUsage,' +
+					'RequestMappingAnnotation,' +
+					'RequestParamType,' +
+					'RequiredModifiers,' +
+					'RestrictedApi,' +
+					'ReturnValueIgnored,' +
+					'SelfAssertion,' +
+					'SelfAssignment,' +
+					'SelfComparison,' +
+					'SelfEquals,' +
+					'SetUnrecognized,' +
+					'ShouldHaveEvenArgs,' +
+					'SizeGreaterThanOrEqualsZero,' +
+					'Slf4jLogStatement,' +
+					'Slf4jLoggerDeclarationSlf4jLoggerDeclaration,' +
+					'SpringMvcAnnotation,' +
+					'StreamToString,' +
+					'StringBuilderInitWithChar,' +
+					'StringJoin,' +
+					'SubstringOfZero,' +
+					'SuppressWarningsDeprecated,' +
+					'TemporalAccessorGetChronoField,' +
+					'TestParametersNotInitialized,' +
+					'TheoryButNoTheories,' +
+					'ThreadBuilderNameWithPlaceholder,' +
+					'ThrowIfUncheckedKnownChecked,' +
+					'ThrowNull,' +
+					'TimeZoneUsage,' +
+					'TreeToString,' +
+					'TryFailThrowable,' +
+					'TypeParameterQualifier,' +
+					'UnicodeDirectionalityCharacters,' +
+					'UnicodeInCode,' +
+					'UnnecessaryCheckNotNull,' +
+					'UnnecessaryTypeArgument,' +
+					'UnsafeWildcard,' +
+					'UnusedAnonymousClass,' +
+					'UnusedCollectionModifiedInPlace,' +
+					'VarTypeName,' +
+					'WrongOneof,' +
+					'XorPower,' +
+					'ZoneIdOfZ,'
+					)
+		}
+	}
+}

--- a/gradle/sanity-check.gradle
+++ b/gradle/sanity-check.gradle
@@ -1,0 +1,287 @@
+import static java.lang.System.getenv
+
+// apply from: rootProject.file('gradle/spotless.gradle')
+apply plugin: 'net.ltgt.errorprone'
+apply plugin: 'org.openrewrite.rewrite'
+
+rewrite {
+	activeRecipe('com.diffplug.spotless.openrewrite.SanityCheck')
+	activeStyle('com.diffplug.spotless.openrewrite.SpotlessFormat')
+	exclusions.addAll(
+			'**.dirty.java',
+			'**FormatterProperties.java',
+			'**_gradle_node_plugin_example_**',
+			'**gradle/changelog.gradle',
+			'**gradle/java-publish.gradle',
+			'**idea/full.clean.java',
+			'**java-setup.gradle',
+			'**lib-extra/build.gradle',
+			'**lib/build.gradle',
+			'**package-info.java',
+			'**plugin-maven/build.gradle',
+			'**settings.gradle',
+			'**special-tests.gradle',
+			'**testlib/src/main/resources**'
+			)
+	exportDatatables = true
+	failOnDryRunResults = true
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.errorprone {
+		disableWarningsInGeneratedCode = true
+		disable(
+				// avoid
+				'StaticImport',
+				// bug
+				'AddNullMarkedToPackageInfo',
+				'Slf4jLogStatement',
+				'Slf4jLogStatement',
+				)
+		// dev opt-in
+		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
+			// apply
+			errorproneArgs.addAll(
+					'-XepPatchLocation:IN_PLACE',
+					'-XepPatchChecks:' +
+					'AddNullMarkedToPackageInfo,' +
+					'AlwaysThrows,' +
+					'AmbiguousJsonCreator,' +
+					'AndroidInjectionBeforeSuper,' +
+					'ArrayEquals,' +
+					'ArrayFillIncompatibleType,' +
+					'ArrayHashCode,' +
+					'ArrayToString,' +
+					'ArraysAsListPrimitiveArray,' +
+					'AssertJNullnessAssertion,' +
+					'AsyncCallableReturnsNull,' +
+					'AsyncFunctionReturnsNull,' +
+					'AutoValueBuilderDefaultsInConstructor,' +
+					'AutoValueConstructorOrderChecker,' +
+					'AutowiredConstructor,' +
+					'BadAnnotationImplementation,' +
+					'BadShiftAmount,' +
+					'BanJNDI,' +
+					'BoxedPrimitiveEquality,' +
+					'BundleDeserializationCast,' +
+					'CanonicalAnnotationSyntax,' +
+					'CanonicalClassNameUsage,' +
+					'ChainingConstructorIgnoresParameter,' +
+					'CheckNotNullMultipleTimes,' +
+					'CheckReturnValue,' +
+					'ClassCastLambdaUsage,' +
+					'CollectionIncompatibleType,' +
+					'CollectionToArraySafeParameter,' +
+					'CollectorMutability,' +
+					'ComparableType,' +
+					'ComparingThisWithNull,' +
+					'ComparisonOutOfRange,' +
+					'CompatibleWithAnnotationMisuse,' +
+					'CompileTimeConstant,' +
+					'ComputeIfAbsentAmbiguousReference,' +
+					'ConditionalExpressionNumericPromotion,' +
+					'ConstantNaming,' +
+					'ConstantOverflow,' +
+					'DaggerProvidesNull,' +
+					'DangerousLiteralNull,' +
+					'DeadException,' +
+					'DeadThread,' +
+					'DefaultCharset,' +
+					'DereferenceWithNullBranch,' +
+					'DirectReturn,' +
+					'DiscardedPostfixExpression,' +
+					'DoNotCall,' +
+					'DoNotMock,' +
+					'DoubleBraceInitialization,' +
+					'DuplicateMapKeys,' +
+					'DurationFrom,' +
+					'DurationGetTemporalUnit,' +
+					'DurationTemporalUnit,' +
+					'DurationToLongTimeUnit,' +
+					'EagerStringFormatting,' +
+					'EmptyMethod,' +
+					'EmptyMonoZip,' +
+					'EqualsHashCode,' +
+					'EqualsNaN,' +
+					'EqualsNull,' +
+					'EqualsReference,' +
+					'EqualsWrongThing,' +
+					'ExplicitArgumentEnumeration,' +
+					'ExplicitEnumOrdering,' +
+					'FloggerFormatString,' +
+					'FloggerLogString,' +
+					'FloggerLogVarargs,' +
+					'FloggerSplitLogStatement,' +
+					'FluxFlatMapUsage,' +
+					'FluxImplicitBlock,' +
+					'ForOverride,' +
+					'FormatString,' +
+					'FormatStringAnnotation,' +
+					'FormatStringConcatenation,' +
+					'FromTemporalAccessor,' +
+					'FunctionalInterfaceMethodChanged,' +
+					'FunctionalInterfaceMethodChanged,' +
+					'FuturesGetCheckedIllegalExceptionType,' +
+					'FuzzyEqualsShouldNotBeUsedInEqualsMethod,' +
+					'GetClassOnAnnotation,' +
+					'GetClassOnClass,' +
+					'GuardedBy,' +
+					'GuiceAssistedInjectScoping,' +
+					'GuiceAssistedParameters,' +
+					'GuiceInjectOnFinalField,' +
+					'HashtableContains,' +
+					'IdentityBinaryExpression,' +
+					'IdentityConversion,' +
+					'IdentityHashMapBoxing,' +
+					'Immutable,' +
+					'ImmutableEnumChecker,' +
+					'ImmutablesSortedSetComparator,' +
+					'ImpossibleNullComparison,' +
+					'Incomparable,' +
+					'IncompatibleArgumentType,' +
+					'IncompatibleModifiers,' +
+					'IndexOfChar,' +
+					'InexactVarargsConditional,' +
+					'InfiniteRecursion,' +
+					'InjectMoreThanOneScopeAnnotationOnClass,' +
+					'InjectOnMemberAndConstructor,' +
+					'InlineMeValidator,' +
+					'InstantTemporalUnit,' +
+					'InvalidJavaTimeConstant,' +
+					'InvalidPatternSyntax,' +
+					'InvalidTimeZoneID,' +
+					'InvalidZoneId,' +
+					'IsInstanceIncompatibleType,' +
+					'IsInstanceLambdaUsage,' +
+					'IsInstanceOfClass,' +
+					'IsLoggableTagLength,' +
+					'JUnit3TestNotRun,' +
+					'JUnit4ClassAnnotationNonStatic,' +
+					'JUnit4SetUpNotRun,' +
+					'JUnit4TearDownNotRun,' +
+					'JUnit4TestNotRun,' +
+					'JUnit4TestsNotRunWithinEnclosed,' +
+					'JUnitAssertSameCheck,' +
+					'JUnitClassModifiers,' +
+					'JUnitMethodDeclaration,' +
+					'JUnitNullaryParameterizedTestDeclaration,' +
+					'JUnitParameterMethodNotFound,' +
+					'JUnitValueSource,' +
+					'JavaxInjectOnAbstractMethod,' +
+					'JodaToSelf,' +
+					'LenientFormatStringValidation,' +
+					'LexicographicalAnnotationAttributeListing,' +
+					'LexicographicalAnnotationListing,' +
+					'LiteByteStringUtf8,' +
+					'LocalDateTemporalAmount,' +
+					'LockOnBoxedPrimitive,' +
+					'LoopConditionChecker,' +
+					'LossyPrimitiveCompare,' +
+					'MathRoundIntLong,' +
+					'MislabeledAndroidString,' +
+					'MisleadingEmptyVarargs,' +
+					'MisleadingEscapedSpace,' +
+					'MisplacedScopeAnnotations,' +
+					'MissingOverride,' +
+					'MissingSuperCall,' +
+					'MissingTestCall,' +
+					'MisusedDayOfYear,' +
+					'MisusedWeekYear,' +
+					'MixedDescriptors,' +
+					'MockitoMockClassReference,' +
+					'MockitoStubbing,' +
+					'MockitoUsage,' +
+					'ModifyingCollectionWithItself,' +
+					'MongoDBTextFilterUsage,' +
+					'MoreThanOneInjectableConstructor,' +
+					'MustBeClosedChecker,' +
+					'NCopiesOfChar,' +
+					'NestedOptionals,' +
+					'NestedPublishers,' +
+					'NoCanIgnoreReturnValueOnClasses,' +
+					'NonCanonicalStaticImport,' +
+					'NonEmptyMono,' +
+					'NonFinalCompileTimeConstant,' +
+					'NonRuntimeAnnotation,' +
+					'NonStaticImport,' +
+					'NullArgumentForNonNullParameter,' +
+					'NullTernary,' +
+					'NullableOnContainingClass,' +
+					'OptionalEquality,' +
+					'OptionalMapUnusedValue,' +
+					'OptionalOfRedundantMethod,' +
+					'OptionalOrElseGet,' +
+					'OverlappingQualifierAndScopeAnnotation,' +
+					'OverridesJavaxInjectableMethod,' +
+					'PackageInfo,' +
+					'ParametersButNotParameterized,' +
+					'ParcelableCreator,' +
+					'PeriodFrom,' +
+					'PeriodGetTemporalUnit,' +
+					'PeriodTimeMath,' +
+					'PreconditionsInvalidPlaceholder,' +
+					'PrimitiveComparison,' +
+					'PrivateSecurityContractProtoAccess,' +
+					'ProtoBuilderReturnValueIgnored,' +
+					'ProtoStringFieldReferenceEquality,' +
+					'ProtoTruthMixedDescriptors,' +
+					'ProtocolBufferOrdinal,' +
+					'ProvidesMethodOutsideOfModule,' +
+					'RandomCast,' +
+					'RandomModInteger,' +
+					'RectIntersectReturnValueIgnored,' +
+					'RedundantSetterCall,' +
+					'RedundantStringConversion,' +
+					'RedundantStringEscape,' +
+					'RefasterAnyOfUsage,' +
+					'RequestMappingAnnotation,' +
+					'RequestParamType,' +
+					'RequiredModifiers,' +
+					'RestrictedApi,' +
+					'ReturnValueIgnored,' +
+					'SelfAssertion,' +
+					'SelfAssignment,' +
+					'SelfComparison,' +
+					'SelfEquals,' +
+					'SetUnrecognized,' +
+					'ShouldHaveEvenArgs,' +
+					'SizeGreaterThanOrEqualsZero,' +
+					'Slf4jLogStatement,' +
+					'Slf4jLoggerDeclarationSlf4jLoggerDeclaration,' +
+					'SpringMvcAnnotation,' +
+					'StreamToString,' +
+					'StringBuilderInitWithChar,' +
+					'StringJoin,' +
+					'SubstringOfZero,' +
+					'SuppressWarningsDeprecated,' +
+					'TemporalAccessorGetChronoField,' +
+					'TestParametersNotInitialized,' +
+					'TheoryButNoTheories,' +
+					'ThreadBuilderNameWithPlaceholder,' +
+					'ThrowIfUncheckedKnownChecked,' +
+					'ThrowNull,' +
+					'TimeZoneUsage,' +
+					'TreeToString,' +
+					'TryFailThrowable,' +
+					'TypeParameterQualifier,' +
+					'UnicodeDirectionalityCharacters,' +
+					'UnicodeInCode,' +
+					'UnnecessaryCheckNotNull,' +
+					'UnnecessaryTypeArgument,' +
+					'UnsafeWildcard,' +
+					'UnusedAnonymousClass,' +
+					'UnusedCollectionModifiedInPlace,' +
+					'VarTypeName,' +
+					'WrongOneof,' +
+					'XorPower,' +
+					'ZoneIdOfZ,'
+					)
+		}
+	}
+}
+
+dependencies {
+	errorprone('com.google.errorprone:error_prone_core:2.42.0')
+	errorprone('tech.picnic.error-prone-support:error-prone-contrib:0.25.0')
+	errorprone('tech.picnic.error-prone-support:refaster-runner:0.25.0')
+}

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtSortMembers.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtSortMembers.java
@@ -98,64 +98,84 @@ public final class EclipseJdtSortMembers {
 			this.contents = contents;
 		}
 
+		@Override
 		public void addBufferChangedListener(IBufferChangedListener listener) {}
 
+		@Override
 		public void append(char[] text) {}
 
+		@Override
 		public void append(String text) {}
 
+		@Override
 		public void close() {}
 
+		@Override
 		public char getChar(int position) {
 			return '\u0000';
 		}
 
+		@Override
 		public char[] getCharacters() {
 			return contents.toCharArray();
 		}
 
+		@Override
 		public String getContents() {
 			return contents;
 		}
 
+		@Override
 		public int getLength() {
 			return 0;
 		}
 
+		@Override
 		public IOpenable getOwner() {
 			return null;
 		}
 
+		@Override
 		public String getText(int offset, int length) {
 			return null;
 		}
 
+		@Override
 		public IResource getUnderlyingResource() {
 			return null;
 		}
 
+		@Override
 		public boolean hasUnsavedChanges() {
 			return false;
 		}
 
+		@Override
 		public boolean isClosed() {
 			return false;
 		}
 
+		@Override
 		public boolean isReadOnly() {
 			return true;
 		}
 
+		@Override
 		public void removeBufferChangedListener(IBufferChangedListener listener) {}
 
+		@Override
 		public void replace(int position, int length, char[] text) {}
 
+		@Override
 		public void replace(int position, int length, String text) {}
 
+		@Override
 		public void save(IProgressMonitor progress, boolean force) {}
 
+		@Override
 		public void setContents(char[] contents) {}
 
+		@Override
 		public void setContents(String contents) {
 			this.contents = contents;
 		}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
@@ -202,8 +202,8 @@ public final class GitWorkarounds {
 			return new IOException("Empty 'commondir' file: " + commonDir.getAbsolutePath());
 		}
 
-		@SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 		@Override
+		@SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 		public FileRepositoryBuilder readEnvironment(SystemReader sr) {
 			super.readEnvironment(sr);
 

--- a/lib/src/compatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public class KtLintCompat0Dot48Dot0Adapter implements KtLintCompatAdapter {
 	private static EditorConfigOverride createEditorConfigOverride(final List<Rule> rules, Map<String, Object> editorConfigOverrideMap) {
 		// Get properties from rules in the rule sets
 		Stream<EditorConfigProperty<?>> ruleProperties = rules.stream()
-				.filter(rule -> rule instanceof UsesEditorConfigProperties)
+				.filter(UsesEditorConfigProperties.class::isInstance)
 				.flatMap(rule -> ((UsesEditorConfigProperties) rule).getEditorConfigProperties().stream());
 
 		// Create a mapping of properties to their names based on rule properties and default properties

--- a/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot49Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat0Dot49Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat0Dot49Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot50Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat0Dot50Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat0Dot50Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat1Dot0Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat1Dot0Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatFormatterFunc.java
+++ b/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ public class GoogleJavaFormatFormatterFunc implements FormatterFunc {
 		this.formatter = new Formatter(builder.build());
 	}
 
-	@Override
 	@Nonnull
+	@Override
 	public String apply(@Nonnull String input) throws Exception {
 		String formatted = formatter.formatSource(input);
 		String removedUnused = RemoveUnusedImports.removeUnusedImports(formatted);

--- a/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatRemoveUnusedImporterFormatterFunc.java
+++ b/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatRemoveUnusedImporterFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ public class GoogleJavaFormatRemoveUnusedImporterFormatterFunc implements Format
 		this.version = Objects.requireNonNull(version);
 	}
 
-	@Override
 	@Nonnull
+	@Override
 	public String apply(@Nonnull String input) throws Exception {
 		return RemoveUnusedImports.removeUnusedImports(input);
 	}

--- a/lib/src/jackson/java/com/diffplug/spotless/glue/yaml/JacksonYamlFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/yaml/JacksonYamlFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ public class JacksonYamlFormatterFunc extends AJacksonFormatterFunc {
 		}
 	}
 
+	@Override
 	protected JsonFactory makeJsonFactory() {
 		YAMLFactoryBuilder yamlFactoryBuilder = new YAMLFactoryBuilder(new YAMLFactory());
 

--- a/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
+++ b/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
@@ -63,13 +63,13 @@ public final class KtfmtFormatterFunc implements FormatterFunc {
 
 		if (ktfmtFormattingOptions != null) {
 			formattingOptions = formattingOptions.copy(
-				ktfmtFormattingOptions.getMaxWidth().orElse(formattingOptions.getMaxWidth()),
-				ktfmtFormattingOptions.getBlockIndent().orElse(formattingOptions.getBlockIndent()),
-				ktfmtFormattingOptions.getContinuationIndent().orElse(formattingOptions.getContinuationIndent()),
+				ktfmtFormattingOptions.getMaxWidth().orElseGet(formattingOptions::getMaxWidth),
+				ktfmtFormattingOptions.getBlockIndent().orElseGet(formattingOptions::getBlockIndent),
+				ktfmtFormattingOptions.getContinuationIndent().orElseGet(formattingOptions::getContinuationIndent),
 				ktfmtFormattingOptions.getTrailingCommaManagementStrategy()
 					.map(KtfmtTrailingCommaManagementStrategy::toFormatterTrailingCommaManagementStrategy)
-					.orElse(formattingOptions.getTrailingCommaManagementStrategy()),
-				ktfmtFormattingOptions.getRemoveUnusedImports().orElse(formattingOptions.getRemoveUnusedImports()),
+					.orElseGet(formattingOptions::getTrailingCommaManagementStrategy),
+				ktfmtFormattingOptions.getRemoveUnusedImports().orElseGet(formattingOptions::getRemoveUnusedImports),
 				formattingOptions.getDebuggingPrintOpsAfterFormatting());
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -103,8 +103,7 @@ public final class FileSignature implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 		private final List<File> files;
-		@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-		private transient @Nullable FileSignature cached;
+		@Nullable private transient @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED") FileSignature cached;
 
 		private Promised(List<File> files, @Nullable FileSignature cached) {
 			this.files = files;
@@ -146,11 +145,11 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	private static final boolean machineIsWin = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+	private static final boolean MACHINE_IS_WIN = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
 
 	/** Returns true if this JVM is running on a windows machine. */
 	public static boolean machineIsWin() {
-		return machineIsWin;
+		return MACHINE_IS_WIN;
 	}
 
 	/** Transforms a native path to a unix one. */

--- a/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
@@ -33,8 +33,7 @@ final class FilterByContentPatternFormatterStep extends DelegateFormatterStep {
 		this.contentPattern = Pattern.compile(Objects.requireNonNull(contentPattern));
 	}
 
-	@Override
-	public @Nullable String format(String raw, File file) throws Exception {
+	@Nullable public @Override String format(String raw, File file) throws Exception {
 		Objects.requireNonNull(raw, "raw");
 		Objects.requireNonNull(file, "file");
 		if (contentPattern.matcher(raw).find() == (onMatch == OnMatch.INCLUDE)) {

--- a/lib/src/main/java/com/diffplug/spotless/FilterByFileFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FilterByFileFormatterStep.java
@@ -30,8 +30,7 @@ final class FilterByFileFormatterStep extends DelegateFormatterStep {
 		this.filter = Objects.requireNonNull(filter);
 	}
 
-	@Override
-	public @Nullable String format(String raw, File file) throws Exception {
+	@Nullable public @Override String format(String raw, File file) throws Exception {
 		Objects.requireNonNull(raw, "raw");
 		Objects.requireNonNull(file, "file");
 		if (filter.accept(file)) {

--- a/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
+++ b/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
@@ -134,7 +134,7 @@ public class ForeignExe implements Serializable {
 			errorMsg.append(msgFix);
 			errorMsg.append('\n');
 		}
-		errorMsg.append(cmd.toString());
+		errorMsg.append(cmd);
 		return new RuntimeException(errorMsg.toString());
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -143,13 +143,13 @@ public final class Formatter implements Serializable, AutoCloseable {
 		for (int i = 0; i < formatter.getSteps().size(); i++) {
 			Throwable exception = exceptionPerStep.get(i);
 			if (exception != null && exception != LintState.formatStepCausedNoChange()) {
-				logger.error("Step '{}' found problem in '{}':\n{}", formatter.getSteps().get(i).getName(), file.getName(), exception.getMessage(), exception);
+				LOGGER.error("Step '{}' found problem in '{}':\n{}", formatter.getSteps().get(i).getName(), file.getName(), exception.getMessage(), exception);
 				throw ThrowingEx.asRuntimeRethrowError(exception);
 			}
 		}
 	}
 
-	private static final Logger logger = LoggerFactory.getLogger(Formatter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Formatter.class);
 
 	/**
 	 * Returns the result of calling all of the FormatterSteps, while also
@@ -220,8 +220,8 @@ public final class Formatter implements Serializable, AutoCloseable {
 				&& steps.equals(other.steps);
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
+	@SuppressWarnings("rawtypes")
 	public void close() {
 		for (FormatterStep step : steps) {
 			try {

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class JarState implements Serializable {
 
-	private static final Logger logger = LoggerFactory.getLogger(JarState.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JarState.class);
 
 	// Let the classloader be overridden for tools using different approaches to classloading
 	@Nullable private static ClassLoader forcedClassLoader;
@@ -53,7 +53,7 @@ public final class JarState implements Serializable {
 	/** Overrides the classloader used by all JarStates. */
 	public static void setForcedClassLoader(@Nullable ClassLoader forcedClassLoader) {
 		if (!Objects.equals(JarState.forcedClassLoader, forcedClassLoader)) {
-			logger.info("Overriding the forced classloader for JarState from {} to {}", JarState.forcedClassLoader, forcedClassLoader);
+			LOGGER.info("Overriding the forced classloader for JarState from {} to {}", JarState.forcedClassLoader, forcedClassLoader);
 		}
 		JarState.forcedClassLoader = forcedClassLoader;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -34,7 +34,7 @@ public enum LineEnding {
 	/** Uses the same line endings as Git, using {@code .gitattributes} and the {@code core.eol} property. */
 	GIT_ATTRIBUTES {
 		/** .gitattributes is path-specific, so you must use {@link LineEnding#createPolicy(File, Supplier)}. */
-		@Override @Deprecated
+		@Deprecated @Override
 		public Policy createPolicy() {
 			return super.createPolicy();
 		}
@@ -42,7 +42,7 @@ public enum LineEnding {
 	/** Uses the same line endings as Git, and assumes that every single file being formatted will have the same line ending. */
 	GIT_ATTRIBUTES_FAST_ALLSAME {
 		/** .gitattributes is path-specific, so you must use {@link LineEnding#createPolicy(File, Supplier)}. */
-		@Override @Deprecated
+		@Deprecated @Override
 		public Policy createPolicy() {
 			return super.createPolicy();
 		}
@@ -84,7 +84,7 @@ public enum LineEnding {
 	/** Should use {@link #createPolicy(File, Supplier)} instead, but this will work iff its a path-independent LineEnding policy. */
 	public Policy createPolicy() {
 		switch (this) {
-		case PLATFORM_NATIVE:	return _platformNativePolicy;
+		case PLATFORM_NATIVE:	return _PLATFORM_NATIVE_POLICY;
 		case WINDOWS:			return WINDOWS_POLICY;
 		case UNIX:				return UNIX_POLICY;
 		case MAC_CLASSIC:		return MAC_CLASSIC_POLICY;
@@ -152,9 +152,9 @@ public enum LineEnding {
 	private static final Policy UNIX_POLICY = new ConstantLineEndingPolicy(UNIX.str());
     private static final Policy MAC_CLASSIC_POLICY = new ConstantLineEndingPolicy(MAC_CLASSIC.str());
     private static final Policy PRESERVE_POLICY = new PreserveLineEndingPolicy();
-	private static final String _platformNative = System.getProperty("line.separator");
-	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
-	private static final boolean nativeIsWin = _platformNative.equals(WINDOWS.str());
+	private static final String _PLATFORM_NATIVE = System.getProperty("line.separator");
+	private static final Policy _PLATFORM_NATIVE_POLICY = new ConstantLineEndingPolicy(_PLATFORM_NATIVE);
+	private static final boolean NATIVE_IS_WIN = _PLATFORM_NATIVE.equals(WINDOWS.str());
 
 	/**
 	 * @deprecated Using the system-native line endings to detect the windows operating system has turned out
@@ -164,13 +164,13 @@ public enum LineEnding {
 	 */
 	@Deprecated
 	public static boolean nativeIsWin() {
-		return nativeIsWin;
+		return NATIVE_IS_WIN;
 	}
 
 	/** Returns the standard line ending for this policy. */
 	public String str() {
 		switch (this) {
-		case PLATFORM_NATIVE:	return _platformNative;
+		case PLATFORM_NATIVE:	return _PLATFORM_NATIVE;
 		case WINDOWS:			return "\r\n";
 		case UNIX:				return "\n";
 		case MAC_CLASSIC:		return "\r";

--- a/lib/src/main/java/com/diffplug/spotless/LintState.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintState.java
@@ -197,10 +197,10 @@ public class LintState {
 
 	/** Returns the DirtyState which corresponds to {@code isClean()}. */
 	public static LintState clean() {
-		return isClean;
+		return IS_CLEAN;
 	}
 
-	private static final LintState isClean = new LintState(DirtyState.clean(), null);
+	private static final LintState IS_CLEAN = new LintState(DirtyState.clean(), null);
 
 	static Throwable formatStepCausedNoChange() {
 		return FormatterCausedNoChange.INSTANCE;

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -153,7 +153,7 @@ public final class PaddedCell {
 		// @formatter:off
 		switch (type) {
 		case CONVERGE:	return steps.get(steps.size() - 1);
-		case CYCLE:		return Collections.min(steps, Comparator.comparing(String::length).thenComparing(Function.identity()));
+		case CYCLE:		return Collections.min(steps, Comparator.comparingInt(String::length).thenComparing(Function.identity()));
 		case DIVERGE:	throw new IllegalArgumentException("No canonical form for a diverging result");
 		default:	throw new IllegalArgumentException("Unknown type: " + type);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/RingBufferByteArrayOutputStream.java
+++ b/lib/src/main/java/com/diffplug/spotless/RingBufferByteArrayOutputStream.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -115,13 +117,13 @@ class RingBufferByteArrayOutputStream extends ByteArrayOutputStream {
 		return result;
 	}
 
-	@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "We want to use the default encoding here since this is contract on ByteArrayOutputStream")
 	@Override
+	@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "We want to use the default encoding here since this is contract on ByteArrayOutputStream")
 	public synchronized String toString() {
 		if (!isOverLimit) {
-			return super.toString();
+			return super.toString(UTF_8);
 		}
-		return new String(buf, zeroIndexPointer, limit - zeroIndexPointer) + new String(buf, 0, zeroIndexPointer);
+		return new String(buf, zeroIndexPointer, limit - zeroIndexPointer, UTF_8) + new String(buf, 0, zeroIndexPointer, UTF_8);
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
+++ b/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
@@ -76,7 +76,7 @@ public final class SpotlessCache {
 	}
 
 	static SpotlessCache instance() {
-		return instance;
+		return INSTANCE;
 	}
 
 	/**
@@ -84,9 +84,9 @@ public final class SpotlessCache {
 	 */
 	private static void clear() {
 		List<URLClassLoader> toDelete;
-		synchronized (instance) {
-			toDelete = new ArrayList<>(instance.cache.values());
-			instance.cache.clear();
+		synchronized (INSTANCE) {
+			toDelete = new ArrayList<>(INSTANCE.cache.values());
+			INSTANCE.cache.clear();
 		}
 		for (URLClassLoader classLoader : toDelete) {
 			try {
@@ -104,7 +104,7 @@ public final class SpotlessCache {
 	 * If {@code key} is null, the clear will always happen (as though null != null).
 	 */
 	public static boolean clearOnce(@Nullable Object key) {
-		synchronized (instance) {
+		synchronized (INSTANCE) {
 			if (key == null) {
 				lastClear = null;
 			} else if (key.equals(lastClear)) {
@@ -117,5 +117,5 @@ public final class SpotlessCache {
 		return true;
 	}
 
-	private static final SpotlessCache instance = new SpotlessCache();
+	private static final SpotlessCache INSTANCE = new SpotlessCache();
 }

--- a/lib/src/main/java/com/diffplug/spotless/ValuePerStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/ValuePerStep.java
@@ -33,8 +33,7 @@ class ValuePerStep<T> extends AbstractList<T> {
 		this.size = formatter.getSteps().size();
 	}
 
-	@Override
-	public @Nullable T set(int index, T newValue) {
+	@Nullable public @Override T set(int index, T newValue) {
 		if (index < 0 || index >= size) {
 			throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
+++ b/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  * The user of the API should be warned that it may unexpectedly disappear in future versions of
  * Spotless. Usually the best place to put this warning is in the API's class JavaDoc.
  */
+@Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({
 		ElementType.ANNOTATION_TYPE,
@@ -36,7 +37,6 @@ import java.lang.annotation.Target;
 		ElementType.METHOD,
 		ElementType.TYPE
 })
-@Documented
 public @interface Internal {
 
 }

--- a/lib/src/main/java/com/diffplug/spotless/annotations/ReturnValuesAreNonnullByDefault.java
+++ b/lib/src/main/java/com/diffplug/spotless/annotations/ReturnValuesAreNonnullByDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,6 @@ import javax.annotation.meta.TypeQualifierDefault;
 
 @Documented
 @Nonnull
-@TypeQualifierDefault(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@TypeQualifierDefault(ElementType.METHOD)
 public @interface ReturnValuesAreNonnullByDefault {}

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * <a href="https://github.com/biomejs/biome">https://github.com/biomejs/biome</a>.
  */
 final class BiomeExecutableDownloader {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeExecutableDownloader.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeExecutableDownloader.class);
 
 	/**
 	 * The checksum algorithm to use for checking the integrity of downloaded files.
@@ -106,7 +106,7 @@ final class BiomeExecutableDownloader {
 		if (executableDir != null) {
 			Files.createDirectories(executableDir);
 		}
-		logger.info("Attempting to download Biome from '{}' to '{}'", url, executablePath);
+		LOGGER.info("Attempting to download Biome from '{}' to '{}'", url, executablePath);
 		var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
 		var handler = BodyHandlers.ofFile(executablePath, WRITE_OPTIONS);
 		var response = HttpClient.newBuilder().followRedirects(Redirect.NORMAL).build().send(request, handler);
@@ -118,7 +118,7 @@ final class BiomeExecutableDownloader {
 			throw new IOException("Failed to download file from " + url + ", file is empty or does not exist");
 		}
 		writeChecksumFile(downloadedFile, checksumPath);
-		logger.debug("Biome was downloaded successfully to '{}'", downloadedFile);
+		LOGGER.debug("Biome was downloaded successfully to '{}'", downloadedFile);
 		return downloadedFile;
 	}
 
@@ -142,13 +142,13 @@ final class BiomeExecutableDownloader {
 	 */
 	public Path ensureDownloaded(String version) throws IOException, InterruptedException {
 		var platform = Platform.guess();
-		logger.debug("Ensuring that Biome for platform '{}' is downloaded", platform);
+		LOGGER.debug("Ensuring that Biome for platform '{}' is downloaded", platform);
 		var existing = findDownloaded(version);
 		if (existing.isPresent()) {
-			logger.debug("Biome was already downloaded, using executable at '{}'", existing.orElseThrow());
+			LOGGER.debug("Biome was already downloaded, using executable at '{}'", existing.orElseThrow());
 			return existing.orElseThrow();
 		} else {
-			logger.debug("Biome was not yet downloaded, attempting to download executable");
+			LOGGER.debug("Biome was not yet downloaded, attempting to download executable");
 			return download(version);
 		}
 	}
@@ -169,7 +169,7 @@ final class BiomeExecutableDownloader {
 	public Optional<Path> findDownloaded(String version) throws IOException {
 		var platform = Platform.guess();
 		var executablePath = getExecutablePath(version, platform);
-		logger.debug("Checking Biome executable at {}", executablePath);
+		LOGGER.debug("Checking Biome executable at {}", executablePath);
 		return checkFileWithChecksum(executablePath) ? Optional.ofNullable(executablePath) : Optional.empty();
 	}
 
@@ -183,26 +183,26 @@ final class BiomeExecutableDownloader {
 	 */
 	private boolean checkFileWithChecksum(Path filePath) {
 		if (!Files.exists(filePath)) {
-			logger.debug("File '{}' does not exist yet", filePath);
+			LOGGER.debug("File '{}' does not exist yet", filePath);
 			return false;
 		}
 		if (Files.isDirectory(filePath)) {
-			logger.debug("File '{}' exists, but is a directory", filePath);
+			LOGGER.debug("File '{}' exists, but is a directory", filePath);
 			return false;
 		}
 		var checksumPath = getChecksumPath(filePath);
 		if (!Files.exists(checksumPath)) {
-			logger.debug("File '{}' exists, but checksum file '{}' does not", filePath, checksumPath);
+			LOGGER.debug("File '{}' exists, but checksum file '{}' does not", filePath, checksumPath);
 			return false;
 		}
 		if (Files.isDirectory(checksumPath)) {
-			logger.debug("Checksum file '{}' exists, but is a directory", checksumPath);
+			LOGGER.debug("Checksum file '{}' exists, but is a directory", checksumPath);
 			return false;
 		}
 		try {
 			var actualChecksum = computeChecksum(filePath, CHECKSUM_ALGORITHM);
 			var expectedChecksum = readTextFile(checksumPath, StandardCharsets.ISO_8859_1);
-			logger.debug("Expected checksum: {}, actual checksum: {}", expectedChecksum, actualChecksum);
+			LOGGER.debug("Expected checksum: {}, actual checksum: {}", expectedChecksum, actualChecksum);
 			return Objects.equals(expectedChecksum, actualChecksum);
 		} catch (final IOException ignored) {
 			return false;
@@ -261,7 +261,7 @@ final class BiomeExecutableDownloader {
 		var parent = file.getParent();
 		var base = parent != null ? parent : file;
 		var fileName = file.getFileName();
-		var checksumName = fileName != null ? fileName.toString() + ".sha256" : "checksum.sha256";
+		var checksumName = fileName != null ? fileName + ".sha256" : "checksum.sha256";
 		return base.resolve(checksumName);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * Settings and constants for Biome to use.
  */
 public final class BiomeSettings {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeSettings.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeSettings.class);
 
 	private static final String CONFIG_NAME = "biome.json";
 	private static final String DEFAULT_VERSION = "1.2.0";
@@ -106,7 +106,7 @@ public final class BiomeSettings {
 			}
 			return actualMajor == major && actualMinor == minor && actualPatch == patch;
 		} catch (final Exception e) {
-			logger.warn("Failed to parse biome version string '{}'. Expected format is 'major.minor.patch'.", version, e);
+			LOGGER.warn("Failed to parse biome version string '{}'. Expected format is 'major.minor.patch'.", version, e);
 			return false;
 		}
 	}

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ import com.diffplug.spotless.ProcessRunner;
  * the network when no executable path is provided explicitly.
  */
 public final class BiomeStep {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeStep.class);
 
 	/**
 	 * Path to the directory with the {@code biome.json} config file, can be
@@ -136,7 +135,7 @@ public final class BiomeStep {
 			newPermissions.add(permission);
 			Files.setPosixFilePermissions(file, newPermissions);
 		} catch (final Exception ignore) {
-			logger.debug("Unable to add POSIX permission '{}' to file '{}'", permission, file);
+			LOGGER.debug("Unable to add POSIX permission '{}' to file '{}'", permission, file);
 		}
 	}
 
@@ -298,8 +297,8 @@ public final class BiomeStep {
 		var resolvedPathToExe = resolveExe();
 		validateBiomeExecutable(resolvedPathToExe);
 		validateBiomeConfigPath(configPath, version);
-		logger.debug("Using Biome executable located at  '{}'", resolvedPathToExe);
-		var exeSignature = FileSignature.signAsList(Set.of(new File(resolvedPathToExe)));
+		LOGGER.debug("Using Biome executable located at  '{}'", resolvedPathToExe);
+		var exeSignature = FileSignature.signAsList(new File(resolvedPathToExe));
 		makeExecutable(resolvedPathToExe);
 		return new State(resolvedPathToExe, exeSignature, configPath, language);
 	}
@@ -421,13 +420,13 @@ public final class BiomeStep {
 		private String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
 			var stdin = input.getBytes(StandardCharsets.UTF_8);
 			var args = buildBiomeCommand(file);
-			if (logger.isDebugEnabled()) {
-				logger.debug("Running Biome command to format code: '{}'", String.join(", ", args));
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Running Biome command to format code: '{}'", String.join(", ", args));
 			}
 			var runnerResult = runner.exec(stdin, args);
 			var stdErr = runnerResult.stdErrUtf8();
 			if (!stdErr.isEmpty()) {
-				logger.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
+				LOGGER.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
 			}
 			var formatted = runnerResult.assertExitZero(StandardCharsets.UTF_8);
 			// When biome encounters an ignored file, it does not output any formatted code

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -482,7 +484,7 @@ public final class LicenseHeaderStep {
 			while ((numRead = stream.read(buf)) != -1) {
 				output.write(buf, 0, numRead);
 			}
-			return new String(output.toByteArray());
+			return new String(output.toByteArray(), UTF_8);
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
@@ -47,7 +47,7 @@ public final class FormatAnnotationsStep implements Serializable {
 	 * A type annotation is an annotation that is meta-annotated with @Target({ElementType.TYPE_USE}).
 	 * A type annotation should be formatted on the same line as the type it qualifies.
 	 */
-	private static final List<String> defaultTypeAnnotations =
+	private static final List<String> DEFAULT_TYPE_ANNOTATIONS =
 			// Use simple names because Spotless has no access to the
 			// fully-qualified names or the definitions of the type qualifiers.
 			Arrays.asList(
@@ -431,21 +431,21 @@ public final class FormatAnnotationsStep implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 
-		private final Set<String> typeAnnotations = new HashSet<>(defaultTypeAnnotations);
+		private final Set<String> typeAnnotations = new HashSet<>(DEFAULT_TYPE_ANNOTATIONS);
 
 		// group 1 is the basename of the annotation.
-		private static final String annoNoArgRegex = "@(?:[A-Za-z_][A-Za-z0-9_.]*\\.)?([A-Za-z_][A-Za-z0-9_]*)";
+		private static final String ANNO_NO_ARG_REGEX = "@(?:[A-Za-z_][A-Za-z0-9_.]*\\.)?([A-Za-z_][A-Za-z0-9_]*)";
 		// 3 non-empty cases:  ()  (".*")  (.*)
-		private static final String annoArgRegex = "(?:\\(\\)|\\(\"[^\"]*\"\\)|\\([^\")][^)]*\\))?";
+		private static final String ANNO_ARG_REGEX = "(?:\\(\\)|\\(\"[^\"]*\"\\)|\\([^\")][^)]*\\))?";
 		// group 1 is the basename of the annotation.
-		private static final String annoRegex = annoNoArgRegex + annoArgRegex;
-		private static final String trailingAnnoRegex = annoRegex + "$";
-		private static final Pattern trailingAnnoPattern = Pattern.compile(trailingAnnoRegex);
+		private static final String ANNO_REGEX = ANNO_NO_ARG_REGEX + ANNO_ARG_REGEX;
+		private static final String TRAILING_ANNO_REGEX = ANNO_REGEX + "$";
+		private static final Pattern TRAILING_ANNO_PATTERN = Pattern.compile(TRAILING_ANNO_REGEX);
 
 		// Heuristic: matches if the line might be within a //, /*, or Javadoc comment.
-		private static final Pattern withinCommentPattern = Pattern.compile("//|/\\*(?!.*/*/)|^[ \t]*\\*[ \t]");
+		private static final Pattern WITHIN_COMMENT_PATTERN = Pattern.compile("//|/\\*(?!.*/*/)|^[ \t]*\\*[ \t]");
 		// Don't move an annotation to the start of a comment line.
-		private static final Pattern startsWithCommentPattern = Pattern.compile("^[ \t]*(//|/\\*$|/\\*|void\\b)");
+		private static final Pattern STARTS_WITH_COMMENT_PATTERN = Pattern.compile("^[ \t]*(//|/\\*$|/\\*|void\\b)");
 
 		/**
 		 * @param addedTypeAnnotations simple names to add to Spotless's default list
@@ -473,7 +473,7 @@ public final class FormatAnnotationsStep implements Serializable {
 				String line = lines[i];
 				if (endsWithTypeAnnotation(line)) {
 					String nextLine = lines[i + 1];
-					if (startsWithCommentPattern.matcher(nextLine).find()) {
+					if (STARTS_WITH_COMMENT_PATTERN.matcher(nextLine).find()) {
 						continue;
 					}
 					lines[i] = "";
@@ -490,14 +490,14 @@ public final class FormatAnnotationsStep implements Serializable {
 		boolean endsWithTypeAnnotation(String unixLine) {
 			// Remove trailing newline.
 			String line = unixLine.replaceAll("\\s+$", "");
-			Matcher m = trailingAnnoPattern.matcher(line);
+			Matcher m = TRAILING_ANNO_PATTERN.matcher(line);
 			if (!m.find()) {
 				return false;
 			}
 			String preceding = line.substring(0, m.start());
 			String basename = m.group(1);
 
-			if (withinCommentPattern.matcher(preceding).find()) {
+			if (WITHIN_COMMENT_PATTERN.matcher(preceding).find()) {
 				return false;
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -40,7 +40,7 @@ import com.diffplug.spotless.npm.EslintRestService.FormatOption;
 
 public final class EslintFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(EslintFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EslintFormatterStep.class);
 
 	public static final String NAME = "eslint-format";
 
@@ -109,17 +109,17 @@ public final class EslintFormatterStep {
 				// If any config files are provided, we need to make sure they are at the same location as the node modules
 				// as eslint will try to resolve plugin/config names relatively to the config file location and some
 				// eslint configs contain relative paths to additional config files (such as tsconfig.json e.g.)
-				logger.debug("Copying config file <{}> to <{}> and using the copy", origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
+				LOGGER.debug("Copying config file <{}> to <{}> and using the copy", origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
 				File configFileCopy = NpmResourceHelper.copyFileToDir(origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
 				this.eslintConfigInUse = this.origEslintConfig.withEslintConfigPath(configFileCopy).verify();
 			}
 		}
 
-		@Override
 		@Nonnull
+		@Override
 		public FormatterFunc createFormatterFunc() {
 			try {
-				logger.info("Creating formatter function (starting server)");
+				LOGGER.info("Creating formatter function (starting server)");
 				Runtime runtime = toRuntime();
 				ServerProcessInfo eslintRestServer = runtime.npmRunServer();
 				EslintRestService restService = new EslintRestService(eslintRestServer.getBaseUrl());
@@ -130,11 +130,11 @@ public final class EslintFormatterStep {
 		}
 
 		private void endServer(BaseNpmRestService restService, ServerProcessInfo restServer) throws Exception {
-			logger.info("Closing formatting function (ending server).");
+			LOGGER.info("Closing formatting function (ending server).");
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
@@ -39,7 +39,7 @@ interface ExclusiveFolderAccess {
 
 	final class ExclusiveFolderAccessSharedMutex implements ExclusiveFolderAccess {
 
-		private static final ConcurrentHashMap<String, Lock> mutexes = new ConcurrentHashMap<>();
+		private static final ConcurrentHashMap<String, Lock> MUTEXES = new ConcurrentHashMap<>();
 
 		private final String path;
 
@@ -48,7 +48,7 @@ interface ExclusiveFolderAccess {
 		}
 
 		private Lock getMutex() {
-			return mutexes.computeIfAbsent(path, k -> new ReentrantLock());
+			return MUTEXES.computeIfAbsent(path, k -> new ReentrantLock());
 		}
 
 		@Override

--- a/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
@@ -45,8 +45,8 @@ final class ListableAdapter<T> implements Iterable<T> {
 		return new ListableAdapter<>(delegate);
 	}
 
-	@Override
 	@Nonnull
+	@Override
 	public Iterator<T> iterator() {
 		return delegate.iterator();
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
@@ -29,9 +29,9 @@ import com.diffplug.spotless.ProcessRunner;
 
 public class NodeApp {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeApp.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeApp.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	@Nonnull
 	protected final NodeServerLayout nodeServerLayout;
@@ -54,10 +54,10 @@ public class NodeApp {
 
 	private static NpmProcessFactory processFactory(NpmFormatterStepLocations formatterStepLocations) {
 		if (formatterStepLocations.cacheDir() != null) {
-			logger.info("Caching npm install results in {}.", formatterStepLocations.cacheDir());
+			LOGGER.info("Caching npm install results in {}.", formatterStepLocations.cacheDir());
 			return NodeModulesCachingNpmProcessFactory.create(formatterStepLocations.cacheDir());
 		}
-		logger.debug("Not caching npm install results.");
+		LOGGER.debug("Not caching npm install results.");
 		return StandardNpmProcessFactory.INSTANCE;
 	}
 
@@ -70,7 +70,7 @@ public class NodeApp {
 	}
 
 	void prepareNodeAppLayout() {
-		timedLogger.withInfo("Preparing {} for npm step {}.", this.nodeServerLayout, getClass().getName()).run(() -> {
+		TIMED_LOGGER.withInfo("Preparing {} for npm step {}.", this.nodeServerLayout, getClass().getName()).run(() -> {
 			NpmResourceHelper.assertDirectoryExists(nodeServerLayout.nodeModulesDir());
 			NpmResourceHelper.writeUtf8StringToFile(nodeServerLayout.packageJsonFile(), this.npmConfig.getPackageJsonContent());
 			if (this.npmConfig.getServeScriptContent() != null) {
@@ -87,7 +87,7 @@ public class NodeApp {
 	}
 
 	void npmInstall() {
-		timedLogger.withInfo("Installing npm dependencies for {} with {}.", this.nodeServerLayout, this.npmProcessFactory.describe())
+		TIMED_LOGGER.withInfo("Installing npm dependencies for {} with {}.", this.nodeServerLayout, this.npmProcessFactory.describe())
 				.run(this::optimizedNpmInstall);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
@@ -29,9 +29,9 @@ import com.diffplug.spotless.ProcessRunner.Result;
 
 public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFactory {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeModulesCachingNpmProcessFactory.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeModulesCachingNpmProcessFactory.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	private final File cacheDir;
 
@@ -84,11 +84,11 @@ public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFact
 		public Result waitFor() {
 			String entryName = entryName();
 			if (shadowCopy.entryExists(entryName, NodeServerLayout.NODE_MODULES)) {
-				timedLogger.withInfo("Using cached node_modules for {} from {}", entryName, cacheDir)
+				TIMED_LOGGER.withInfo("Using cached node_modules for {} from {}", entryName, cacheDir)
 						.run(() -> shadowCopy.copyEntryInto(entryName(), NodeServerLayout.NODE_MODULES, nodeServerLayout.nodeModulesDir()));
 				return new CachedResult();
 			} else {
-				Result result = timedLogger.withInfo("calling actual npm install {}", actualNpmInstallProcess.describe())
+				Result result = TIMED_LOGGER.withInfo("calling actual npm install {}", actualNpmInstallProcess.describe())
 						.call(actualNpmInstallProcess::waitFor);
 				assert result.exitCode() == 0;
 				storeShadowCopy(entryName);
@@ -97,7 +97,7 @@ public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFact
 		}
 
 		private void storeShadowCopy(String entryName) {
-			timedLogger.withInfo("Caching node_modules for {} in {}", entryName, cacheDir)
+			TIMED_LOGGER.withInfo("Caching node_modules for {} in {}", entryName, cacheDir)
 					.run(() -> shadowCopy.addEntry(entryName(), new File(nodeServerLayout.nodeModulesDir(), NodeServerLayout.NODE_MODULES)));
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServeApp.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServeApp.java
@@ -26,16 +26,16 @@ import com.diffplug.spotless.ProcessRunner;
 
 public class NodeServeApp extends NodeApp {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeApp.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeApp.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	public NodeServeApp(@Nonnull NodeServerLayout nodeServerLayout, @Nonnull NpmConfig npmConfig, @Nonnull NpmFormatterStepLocations formatterStepLocations) {
 		super(nodeServerLayout, npmConfig, formatterStepLocations);
 	}
 
 	ProcessRunner.LongRunningProcess startNpmServeProcess(UUID nodeServerInstanceId) {
-		return timedLogger.withInfo("Starting npm based server in {} with {}.", this.nodeServerLayout.nodeModulesDir(), this.npmProcessFactory.describe())
+		return TIMED_LOGGER.withInfo("Starting npm based server in {} with {}.", this.nodeServerLayout.nodeModulesDir(), this.npmProcessFactory.describe())
 				.call(() -> npmProcessFactory.createNpmServeProcess(nodeServerLayout, formatterStepLocations, nodeServerInstanceId).start());
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -39,9 +39,9 @@ import com.diffplug.spotless.ThrowingEx;
 
 abstract class NpmFormatterStepStateBase implements Serializable {
 
-	private static final Logger logger = LoggerFactory.getLogger(NpmFormatterStepStateBase.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NpmFormatterStepStateBase.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	@Serial
 	private static final long serialVersionUID = 1460749955865959948L;
@@ -132,11 +132,11 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 						if (server.isAlive()) {
 							server.destroyForcibly();
 							ProcessRunner.Result result = server.result();
-							logger.info("Launching npm server process failed. Process result:\n{}", result);
+							LOGGER.info("Launching npm server process failed. Process result:\n{}", result);
 						}
 					} catch (Throwable t) {
 						ProcessRunner.Result result = ThrowingEx.get(server::result);
-						logger.debug("Unable to forcibly end the server process. Process result:\n{}", result, t);
+						LOGGER.debug("Unable to forcibly end the server process. Process result:\n{}", result, t);
 					}
 					throw timeoutException;
 				}
@@ -194,15 +194,15 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 		@Override
 		public void close() throws Exception {
 			try {
-				logger.trace("Closing npm server in directory <{}> and port <{}>",
+				LOGGER.trace("Closing npm server in directory <{}> and port <{}>",
 						serverPortFile.getParent(), serverPort);
 
 				if (server.isAlive()) {
 					boolean ended = server.waitFor(5, TimeUnit.SECONDS);
 					if (!ended) {
-						logger.info("Force-Closing npm server in directory <{}> and port <{}>", serverPortFile.getParent(), serverPort);
+						LOGGER.info("Force-Closing npm server in directory <{}> and port <{}>", serverPortFile.getParent(), serverPort);
 						server.destroyForcibly().waitFor();
-						logger.trace("Force-Closing npm server in directory <{}> and port <{}> -- Finished", serverPortFile.getParent(), serverPort);
+						LOGGER.trace("Force-Closing npm server in directory <{}> and port <{}> -- Finished", serverPortFile.getParent(), serverPort);
 					}
 				}
 			} finally {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -36,7 +36,7 @@ import com.diffplug.spotless.ThrowingEx;
 
 public final class PrettierFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(PrettierFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(PrettierFormatterStep.class);
 
 	public static final String NAME = "prettier-format";
 
@@ -82,11 +82,11 @@ public final class PrettierFormatterStep {
 			this.prettierConfig = requireNonNull(prettierConfig);
 		}
 
-		@Override
 		@Nonnull
+		@Override
 		public FormatterFunc createFormatterFunc() {
 			try {
-				logger.info("creating formatter function (starting server)");
+				LOGGER.info("creating formatter function (starting server)");
 				ServerProcessInfo prettierRestServer = toRuntime().npmRunServer();
 				PrettierRestService restService = new PrettierRestService(prettierRestServer.getBaseUrl());
 				String prettierConfigOptions = restService.resolveConfig(this.prettierConfig.getPrettierConfigPath(), this.prettierConfig.getOptions());
@@ -97,11 +97,11 @@ public final class PrettierFormatterStep {
 		}
 
 		private void endServer(PrettierRestService restService, ServerProcessInfo restServer) throws Exception {
-			logger.info("Closing formatting function (ending server).");
+			LOGGER.info("Closing formatting function (ending server).");
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
@@ -114,7 +114,7 @@ class PrettierMissingParserException extends RuntimeException implements Lint.Ha
 				.filter(entry -> file.getName().endsWith(entry.getKey()))
 				.findFirst()
 				.map(Map.Entry::getValue)
-				.orElse("prettier-plugin-" + extension(file));
+				.orElseGet(() -> "prettier-plugin-" + extension(file));
 	}
 
 	public String fileType() {

--- a/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
@@ -38,7 +38,7 @@ import com.diffplug.spotless.ThrowingEx;
 
 public final class TsFmtFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(TsFmtFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(TsFmtFormatterStep.class);
 
 	public static final String NAME = "tsfmt-format";
 
@@ -90,8 +90,8 @@ public final class TsFmtFormatterStep {
 			this.inlineTsFmtSettings = inlineTsFmtSettings == null ? new TreeMap<>() : new TreeMap<>(inlineTsFmtSettings);
 		}
 
-		@Override
 		@Nonnull
+		@Override
 		public FormatterFunc createFormatterFunc() {
 			try {
 				Map<String, Object> tsFmtOptions = unifyOptions();
@@ -121,7 +121,7 @@ public final class TsFmtFormatterStep {
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ReflectionHelper {
-	private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	private final RdfFormatterStep.State state;
 	private final ClassLoader classLoader;
 	private final Class<?> JenaRdfDataMgrClass;
@@ -202,10 +202,10 @@ class ReflectionHelper {
 			long col = (long) args[2];
 			String severity = method.getName();
 			if ("warning".equals(severity) && !state.getConfig().isFailOnWarning()) {
-				logger.warn("{}({},{}): {}", this.filePath, line, col, message);
+				LOGGER.warn("{}({},{}): {}", this.filePath, line, col, message);
 			} else {
 				if ("warning".equals(severity)) {
-					logger.error("Formatter fails because of a parser warning. To make the formatter succeed in"
+					LOGGER.error("Formatter fails because of a parser warning. To make the formatter succeed in"
 							+ "the presence of warnings, set the configuration parameter 'failOnWarning' to 'false' (default: 'true')");
 				}
 				throw new RuntimeException(

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -37,7 +37,7 @@ import com.diffplug.spotless.annotations.Internal;
 public class SQLTokenizedFormatter {
 
 	private static final String[] JOIN_BEGIN = {"LEFT", "RIGHT", "INNER", "OUTER", "JOIN"};
-	private static final SQLDialect sqlDialect = SQLDialect.INSTANCE;
+	private static final SQLDialect SQL_DIALECT = SQLDialect.INSTANCE;
 	private DBeaverSQLFormatterConfiguration formatterCfg;
 	private List<Boolean> functionBracket = new ArrayList<>();
 	private List<String> statementDelimiters = new ArrayList<>(2);
@@ -251,7 +251,7 @@ public class SQLTokenizedFormatter {
 				}
 			} else if (token.getType() == TokenType.COMMENT) {
 				boolean isComment = false;
-				String[] slComments = sqlDialect.getSingleLineComments();
+				String[] slComments = SQL_DIALECT.getSingleLineComments();
 				for (String slc : slComments) {
 					if (token.getString().startsWith(slc)) {
 						isComment = true;
@@ -259,7 +259,7 @@ public class SQLTokenizedFormatter {
 					}
 				}
 				if (!isComment) {
-					Pair<String, String> mlComments = sqlDialect.getMultiLineComments();
+					Pair<String, String> mlComments = SQL_DIALECT.getMultiLineComments();
 					if (token.getString().startsWith(mlComments.getFirst())) {
 						index += insertReturnAndIndent(argList, index + 1, indent);
 					}
@@ -385,7 +385,7 @@ public class SQLTokenizedFormatter {
 	}
 
 	private boolean isFunction(String name) {
-		return sqlDialect.getKeywordType(name) == DBPKeywordType.FUNCTION;
+		return SQL_DIALECT.getKeywordType(name) == DBPKeywordType.FUNCTION;
 	}
 
 	private static String getDefaultLineSeparator() {
@@ -406,7 +406,7 @@ public class SQLTokenizedFormatter {
 				final FormatterToken token = argList.get(argIndex);
 				final FormatterToken prevToken = argList.get(argIndex - 1);
 				if (token.getType() == TokenType.COMMENT
-						&& isCommentLine(sqlDialect, token.getString())
+						&& isCommentLine(SQL_DIALECT, token.getString())
 						&& prevToken.getType() != TokenType.END) {
 					s.setCharAt(0, ' ');
 					s.setLength(1);

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
@@ -31,8 +31,8 @@ import java.util.Set;
  */
 class SQLTokensParser {
 
-	private static final String[] twoCharacterSymbol = {"<>", "<=", ">=", "||", "()", "!=", ":=", ".*"};
-	private static final SQLDialect sqlDialect = SQLDialect.INSTANCE;
+	private static final String[] TWO_CHARACTER_SYMBOL = {"<>", "<=", ">=", "||", "()", "!=", ":=", ".*"};
+	private static final SQLDialect SQL_DIALECT = SQLDialect.INSTANCE;
 
 	private final String[][] quoteStrings;
 	private final char structSeparator;
@@ -44,10 +44,10 @@ class SQLTokensParser {
 	private int fPos;
 
 	SQLTokensParser() {
-		this.structSeparator = sqlDialect.getStructSeparator();
-		this.catalogSeparator = sqlDialect.getCatalogSeparator();
-		this.quoteStrings = sqlDialect.getIdentifierQuoteStrings();
-		this.singleLineComments = sqlDialect.getSingleLineComments();
+		this.structSeparator = SQL_DIALECT.getStructSeparator();
+		this.catalogSeparator = SQL_DIALECT.getCatalogSeparator();
+		this.quoteStrings = SQL_DIALECT.getIdentifierQuoteStrings();
+		this.singleLineComments = SQL_DIALECT.getSingleLineComments();
 		this.singleLineCommentStart = new char[this.singleLineComments.length];
 		for (int i = 0; i < singleLineComments.length; i++) {
 			if (singleLineComments[i].isEmpty()) {
@@ -186,9 +186,9 @@ class SQLTokensParser {
 						s.append(fChar);
 					}
 				}
-				return new FormatterToken(TokenType.COMMAND, word + s.toString(), start_pos);
+				return new FormatterToken(TokenType.COMMAND, word + s, start_pos);
 			}
-			if (sqlDialect.getKeywordType(word) != null) {
+			if (SQL_DIALECT.getKeywordType(word) != null) {
 				return new FormatterToken(TokenType.KEYWORD, word, start_pos);
 			}
 			return new FormatterToken(TokenType.NAME, word, start_pos);
@@ -250,7 +250,7 @@ class SQLTokensParser {
 					return new FormatterToken(TokenType.SYMBOL, s.toString(), start_pos);
 				}
 				char ch2 = fBefore.charAt(fPos);
-				for (String aTwoCharacterSymbol : twoCharacterSymbol) {
+				for (String aTwoCharacterSymbol : TWO_CHARACTER_SYMBOL) {
 					if (aTwoCharacterSymbol.charAt(0) == fChar && aTwoCharacterSymbol.charAt(1) == ch2) {
 						fPos++;
 						s.append(ch2);

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -33,7 +33,7 @@ import sortpom.logger.SortPomLogger;
 import sortpom.parameter.PluginParameters;
 
 public class SortPomFormatterFunc implements FormatterFunc {
-	private static final Logger logger = LoggerFactory.getLogger(SortPomFormatterFunc.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SortPomFormatterFunc.class);
 	private final SortPomCfg cfg;
 
 	public SortPomFormatterFunc(SortPomCfg cfg) {
@@ -101,19 +101,19 @@ public class SortPomFormatterFunc implements FormatterFunc {
 
 		@Override
 		public void warn(String content) {
-			logger.warn(content);
+			LOGGER.warn(content);
 		}
 
 		@Override
 		public void info(String content) {
 			if (!quiet) {
-				logger.info(content);
+				LOGGER.info(content);
 			}
 		}
 
 		@Override
 		public void error(String content) {
-			logger.error(content);
+			LOGGER.error(content);
 		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -83,7 +83,7 @@ import groovy.lang.Closure;
 /** Adds a {@code spotless{Name}Check} and {@code spotless{Name}Apply} task. */
 public class FormatExtension {
 
-	private static final Logger logger = LoggerFactory.getLogger(FormatExtension.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(FormatExtension.class);
 
 	final SpotlessExtension spotless;
 	final List<Action<FormatExtension>> lazyActions = new ArrayList<>();
@@ -548,7 +548,7 @@ public class FormatExtension {
 	}
 
 	private static void logDeprecation(String methodName, String replacement) {
-		logger.warn("'{}' is deprecated, use '{}' in your gradle build script instead.", methodName, replacement);
+		LOGGER.warn("'{}' is deprecated, use '{}' in your gradle build script instead.", methodName, replacement);
 	}
 
 	/** Ensures formatting of files via native binary. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
@@ -121,8 +121,7 @@ public class GitRatchetGradle extends GitRatchet<File> {
 		return project;
 	}
 
-	@Override
-	protected @Nullable File getParent(File project) {
+	@Nullable protected @Override File getParent(File project) {
 		return project.getParentFile();
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -142,7 +142,7 @@ final class GradleProvisioner {
 		};
 	}
 
-	private static final Logger logger = LoggerFactory.getLogger(GradleProvisioner.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(GradleProvisioner.class);
 
 	/** Models a request to the provisioner. */
 	private static class Request {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Provider;
@@ -99,6 +97,5 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 		return taskService;
 	}
 
-	@Inject
 	protected abstract BuildEventsListenerRegistry getBuildEventsListenerRegistry();
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -48,7 +48,7 @@ public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 					String path = fileVisitDetails.getPath();
 					File originalSource = new File(getProjectDir().get().getAsFile(), path);
 					try {
-						getLogger().debug("Copying " + fileVisitDetails.getFile() + " to " + originalSource);
+						getLogger().debug("Copying {} to {}", fileVisitDetails.getFile(), originalSource);
 						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 					} catch (IOException e) {
 						throw new RuntimeException(e);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
@@ -40,8 +40,8 @@ public class SpotlessDiagnoseTask extends DefaultTask {
 		return source;
 	}
 
-	@TaskAction
 	@SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+	@TaskAction
 	public void performAction() throws IOException {
 		Path srcRoot = getProject().getProjectDir().toPath();
 		Path diagnoseRoot = getProject().getLayout().getBuildDirectory().getAsFile().get()
@@ -49,7 +49,7 @@ public class SpotlessDiagnoseTask extends DefaultTask {
 		getProject().delete(diagnoseRoot.toFile());
 		try (Formatter formatter = source.buildFormatter()) {
 			for (File file : source.target) {
-				getLogger().debug("Running padded cell check on " + file);
+				getLogger().debug("Running padded cell check on {}", file);
 				PaddedCell padded = PaddedCell.check(formatter, file);
 				if (!padded.misbehaved()) {
 					getLogger().debug("    well-behaved.");

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -137,9 +137,9 @@ public abstract class SpotlessTask extends DefaultTask {
 
 	protected FileCollection target;
 
-	@PathSensitive(PathSensitivity.RELATIVE)
 	@Incremental
 	@InputFiles
+	@PathSensitive(PathSensitivity.RELATIVE)
 	public FileCollection getTarget() {
 		return target;
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
@@ -73,7 +72,6 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 		return taskServiceProvider;
 	}
 
-	@Inject
 	protected abstract FileSystemOperations getFs();
 
 	@TaskAction
@@ -152,7 +150,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 			// Need to copy the original file to the tmp location just to remember the file attributes
 			Files.copy(input.toPath(), cleanFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 
-			getLogger().info("Writing clean file: %s".formatted(cleanFile));
+			getLogger().info("Writing clean file: {}", cleanFile);
 			lintState.getDirtyState().writeCanonicalTo(cleanFile);
 		}
 		if (!lintState.isHasLints()) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -25,7 +25,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileTree;
@@ -122,7 +121,6 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		@Internal
 		abstract DirectoryProperty getProjectDir();
 
-		@Inject
 		protected abstract ObjectFactory getConfigCacheWorkaround();
 
 		void init(SpotlessTaskImpl impl) {
@@ -178,7 +176,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 				@Override
 				public void visitFile(FileVisitDetails fileVisitDetails) {
 					String path = fileVisitDetails.getPath();
-					getLogger().debug("Reading lints for " + path);
+					getLogger().debug("Reading lints for {}", path);
 					LinkedHashMap<String, List<Lint>> lints = SerializableMisc.fromFile(LinkedHashMap.class, fileVisitDetails.getFile());
 					allLints.put(path, lints);
 					lints.values().forEach(list -> total.addAndGet(list.size()));

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
 
 public class Ktlint implements FormatterStepFactory {
-	private static final File defaultEditorConfig = new File(".editorconfig");
+	private static final File DEFAULT_EDITOR_CONFIG = new File(".editorconfig");
 
 	@Parameter
 	private String version;
@@ -46,8 +46,8 @@ public class Ktlint implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(final FormatterStepConfig stepConfig) {
 		String ktlintVersion = version != null ? version : KtLintStep.defaultVersion();
 		FileSignature configPath = null;
-		if (editorConfigPath == null && defaultEditorConfig.exists()) {
-			editorConfigPath = defaultEditorConfig.getPath();
+		if (editorConfigPath == null && DEFAULT_EDITOR_CONFIG.exists()) {
+			editorConfigPath = DEFAULT_EDITOR_CONFIG.getPath();
 		}
 		if (editorConfigPath != null) {
 			configPath = ThrowingEx.get(() -> FileSignature.signAsList(stepConfig.getFileLocator().locateFile(editorConfigPath)));

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -10,7 +10,6 @@ tags:
   - cleanup
 recipeList:
   - org.openrewrite.gradle.EnableGradleBuildCache
-  - org.openrewrite.gradle.EnableGradleParallelExecution
   - org.openrewrite.gradle.GradleBestPractices
   - org.openrewrite.java.RemoveUnusedImports
   - org.openrewrite.java.format.NormalizeFormat

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ plugins {
 	id 'com.gradle.develocity' version '4.2.1'
 	// https://github.com/equodev/equo-ide/blob/main/plugin-gradle/CHANGELOG.md
 	id 'dev.equo.ide' version '1.7.8' apply false
+	id 'net.ltgt.errorprone' version '4.3.0' apply false
 	id 'org.openrewrite.rewrite' version '7.17.0' apply false
 }
 

--- a/testlib/src/main/java/com/diffplug/spotless/ClearGitConfig.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ClearGitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
 @ExtendWith(ClearGitConfig.GitConfigExtension.class)
 @ResourceLock(value = "GIT", mode = ResourceAccessMode.READ_WRITE)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface ClearGitConfig {
 
 	class GitConfigExtension implements BeforeEachCallback, AfterEachCallback {

--- a/testlib/src/main/java/com/diffplug/spotless/ReflectionUtil.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class ReflectionUtil {
 
 	public static void dumpMethod(Method method) {
 		System.out.print(Modifier.toString(method.getModifiers()));
-		System.out.print(" " + method.getReturnType().toString());
+		System.out.print(" " + method.getReturnType());
 		System.out.print(" " + method.getName() + "(");
 		Iterator<Parameter> paramIter = Arrays.asList(method.getParameters()).iterator();
 		while (paramIter.hasNext()) {

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -140,22 +140,22 @@ public class TestProvisioner {
 
 	/** Creates a Provisioner for the mavenCentral repo. */
 	public static Provisioner mavenCentral() {
-		return mavenCentral.get();
+		return MAVEN_CENTRAL.get();
 	}
 
-	private static final Supplier<Provisioner> mavenCentral = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
+	private static final Supplier<Provisioner> MAVEN_CENTRAL = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
 
 	/** Creates a Provisioner for the local maven repo for development purpose. */
 	public static Provisioner mavenLocal() {
-		return mavenLocal.get();
+		return MAVEN_LOCAL.get();
 	}
 
-	private static final Supplier<Provisioner> mavenLocal = () -> createWithRepositories(repo -> repo.mavenLocal());
+	private static final Supplier<Provisioner> MAVEN_LOCAL = () -> createWithRepositories(repo -> repo.mavenLocal());
 
 	/** Creates a Provisioner for the Sonatype snapshots maven repo for development purpose. */
 	public static Provisioner snapshots() {
-		return snapshots.get();
+		return SNAPSHOTS.get();
 	}
 
-	private static final Supplier<Provisioner> snapshots = () -> createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
+	private static final Supplier<Provisioner> SNAPSHOTS = () -> createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
 }

--- a/testlib/src/main/java/com/diffplug/spotless/npm/EslintStyleGuide.java
+++ b/testlib/src/main/java/com/diffplug/spotless/npm/EslintStyleGuide.java
@@ -26,8 +26,8 @@ import javax.annotation.Nonnull;
  */
 public enum EslintStyleGuide {
 	TS_STANDARD_WITH_TYPESCRIPT("standard-with-typescript") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("@typescript-eslint/eslint-plugin", "^5.62.0");
 			dependencies.put("@typescript-eslint/parser", "^5.62.0");
@@ -39,8 +39,8 @@ public enum EslintStyleGuide {
 		}
 	},
 	TS_XO_TYPESCRIPT("xo-typescript") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("eslint-config-xo", "^0.43.1");
 			dependencies.put("eslint-config-xo-typescript", "^1.0.0");
@@ -48,8 +48,8 @@ public enum EslintStyleGuide {
 		}
 	},
 	JS_AIRBNB("airbnb") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("eslint-config-airbnb-base", "^15.0.0");
 			dependencies.put("eslint-plugin-import", "^2.27.5");
@@ -57,16 +57,16 @@ public enum EslintStyleGuide {
 		}
 	},
 	JS_GOOGLE("google") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("eslint-config-google", "^0.14.0");
 			return dependencies;
 		}
 	},
 	JS_STANDARD("standard") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("eslint-config-standard", "^17.1.0");
 			dependencies.put("eslint-plugin-import", "^2.27.5");
@@ -76,8 +76,8 @@ public enum EslintStyleGuide {
 		}
 	},
 	JS_XO("xo") {
-		@Override
-		public @Nonnull Map<String, String> devDependencies() {
+		@Nonnull
+		public @Override Map<String, String> devDependencies() {
 			Map<String, String> dependencies = new LinkedHashMap<>();
 			dependencies.put("eslint-config-xo", "^0.43.1");
 			return dependencies;

--- a/testlib/src/main/java/com/diffplug/spotless/tag/BlackTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/BlackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("black")
+@Target({METHOD, TYPE})
 public @interface BlackTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/BufTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/BufTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("buf")
+@Target({METHOD, TYPE})
 public @interface BufTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/ClangTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/ClangTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("clang")
+@Target({METHOD, TYPE})
 public @interface ClangTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/GofmtTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/GofmtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("gofmt")
+@Target({METHOD, TYPE})
 public @interface GofmtTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/IdeaTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/IdeaTest.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("idea")
+@Target({METHOD, TYPE})
 public @interface IdeaTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/NpmTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/NpmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("npm")
+@Target({METHOD, TYPE})
 public @interface NpmTest {}

--- a/testlib/src/main/java/com/diffplug/spotless/tag/ShfmtTest.java
+++ b/testlib/src/main/java/com/diffplug/spotless/tag/ShfmtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
-@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Tag("shfmt")
+@Target({METHOD, TYPE})
 public @interface ShfmtTest {}


### PR DESCRIPTION

```
 Did you mean 'requireNonNull(version);'?
/Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ShellExtension.java:46: Note: [StaticImport] Identifier should be statically imported
		Objects.requireNonNull(version);
		       ^
    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
  Did you mean 'requireNonNull(version);'?
/Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java:49: Note: [StaticImport] Identifier should be statically imported
		Objects.requireNonNull(version);
		       ^
    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
  Did you mean 'requireNonNull(version);'?
/Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java:62: Note: [StaticImport] Identifier should be statically imported
			cfg.version = Objects.requireNonNull(version);
			                     ^
    (see https://error-prone.picnic.tech/bugpatterns/StaticImport)
  Did you mean 'cfg.version = requireNonNull(version);'?
Refactoring changes were successfully applied to file:///Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java, please check the refactored code and recompile.
Refactoring changes were successfully applied to file:///Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PluginGradlePreconditions.java, please check the refactored code and recompile.
```




on corruption:

```
				         ^
    (see https://error-prone.picnic.tech/refasterrules/StreamRules#StreamOfArray)
  Did you mean 'Arrays.stream(additionalFileContents));'?
/Users/vincent.potucek/IdeaProjects/spotless/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java:108: Note: [Refaster Rule] ImmutableListRules.ImmutableListOf3: Refactoring opportunity
			List<String> args = List.of(exeAbsPath, "format", file.getAbsolutePath());
			                           ^
    (see https://error-prone.picnic.tech/refasterrules/ImmutableListRules#ImmutableListOf3)
  Did you mean 'List<String> args = ImmutableList.of(exeAbsPath, "format", file.getAbsolutePath());'?
/Users/vincent.potucek/IdeaProjects/spotless/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java:189: Note: [RedundantStringConversion] Avoid redundant string conversions when possible
				return new FormatterToken(TokenType.COMMAND, word + s.toString(), start_pos);
				                                                  ^
    (see https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion)
  Did you mean 'return new FormatterToken(TokenType.COMMAND, word + s, start_pos);'?
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
100 warnings

> Task :lib:compileJava FAILED

[Incubating] Problems report is available at: file:///Users/vincent.potucek/IdeaProjects/spotless/build/reports/problems/problems-report.html
21 actionable tasks: 21 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':lib:compileJava'.
> Compilation failed; see the compiler output below.
  /Users/vincent.potucek/IdeaProjects/spotless/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java:37: warning: Unsafe is internal proprietary API and may be removed in a future release
  import sun.misc.Unsafe;
                 ^
  1 error
  100 warnings

BUILD FAILED in 24s
Configuration cache entry stored.
14:34:35: Execution finished 'clean assemble'.
```

relates to:

- https://github.com/junit-team/junit-framework/pull/5006
- https://github.com/diffplug/spotless/pull/2663